### PR TITLE
Architecture + roadmap, grounded in E1–E3 measurements on real ~/.claude data

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,9 +17,24 @@
 
 ## Invariants — do not break
 
-> **TODO**: numbered, non-negotiable design invariants — added as they are discovered, never
-> removed silently. Each one states the rule and the *why* in one or two sentences, with an
-> `evidence:` pointer (experiment/measurement) when the rule rests on an empirical claim.
+Non-negotiable, added as discovered, never removed silently. The authoritative statements (rule +
+*why* + `evidence:`) live in [`docs/design/workflow.md`](docs/design/workflow.md); this is the
+index. Grounded in [`experiments/`](experiments/) E1–E3.
+
+1. **Never auto-write** — human adoption is structural grounding, not a toggle.
+2. **Maintain, not grow** — addition is last-resort behind the recurrence gate; default is maintenance.
+3. **Objective signal is the spine, user correction the overlay** — detection leads with structural
+   failure; phrase mining is rejected as primary; correction detection excludes interrogatives.
+   *evidence:* E1, E2.
+4. **Attribution emits a class that chooses the lever** — violation→enforce, scope-mismatch→
+   generalize, conflict→retire, gap→gated-add; a present-but-ignored rule is never answered with
+   more text. *evidence:* E2.
+5. **Adherence (执行率) is measured, not assumed.** *evidence:* E2.
+6. **Omission needs applicability; without it, output is a candidate, not a verdict** — v1 acts only
+   on objectively-observable behavior. *evidence:* E3.
+7. **Every change passes a gate; prefer zero-oracle objective checks; gate scales with risk.**
+8. **Keep an exploration budget** against routine collapse.
+9. **Observe is read-only and fails safe.**
 
 ## Task lifecycle — the fixed order for every non-trivial change
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3,4 +3,16 @@
 > Smaller, uncommitted follow-ups and deferrals. Roadmap-level items belong in the design docs.
 > Keep this current in real time: add on discovery, remove or check off on completion.
 
-_(none yet)_
+- [ ] **Measure interrogative-filter precision at scale** (Phase 2 entry). E2 sampled precision
+  by hand (~5% → ~50%); needs a labelled measurement across projects under `experiments/`.
+- [ ] **Applicability-estimator calibration** (Phase 2 entry). The omission denominator
+  (`docs/design/attribute.md`) is unvalidated — calibrate against held-out adherence the user
+  confirms before any prose-rule omission verdict ships.
+- [ ] **Locate the commit-signature instruction symbol.** E3's conflict case needs its source
+  symbol identified (system prompt / settings / output-style) so Phase 0 can target the override.
+- [ ] **Resolve the live signature conflict for this repo.** The harness instruction to add
+  `Co-Authored-By: Claude` conflicts with the user's repeated correction (×11); decide retire vs
+  hookify-override. Until resolved, this repo's own commits reproduce the flaw (see E3).
+- [ ] **Decouple E1–E3 phrase lists into config.** The correction/theme phrase sets are inline in
+  the experiment scripts; when the detector becomes product code it must move to config
+  (`CLAUDE.md` "config holds every knob").

--- a/docs/design/attribute.md
+++ b/docs/design/attribute.md
@@ -1,0 +1,41 @@
+# attribute — episode to responsible symbol
+
+Maps each failure episode to the symbol(s) accountable and the action-determining class.
+The make-or-break stage (`DEFINITION §8` hard point 1). Spine: [workflow.md](workflow.md).
+
+## Feasibility
+
+Attribution of a real correction to a *specific* symbol is feasible — every sampled correction
+resolved to a named existing symbol or a confident "no symbol" — **conditional on** the detection
+filter ([detect.md](detect.md)). The bottleneck is mis-detection, not mis-attribution.
+*evidence:* [E2](../../experiments/E2_attribution/).
+
+## The attribution classes
+
+Attribution is not binary; it emits one of four classes, and the class — not the episode — chooses
+the downstream lever:
+
+- **in-scope-violation** — a symbol exists, applies, and was ignored. Lever: *enforcement*
+  (hookify, reposition, or compress the noise competing for attention), never more text.
+- **scope-mismatch** — a symbol covers a narrower scope than the recurring correction. Lever:
+  *generalize* the existing symbol, not a sibling beside it.
+- **gap** — no symbol covers the episode. Lever: *addition*, and only behind the recurrence gate.
+- **conflict** — a symbol actively produces the rejected behavior. Lever: *retire or override* the
+  polluting symbol. This is the thesis in one case (`DEFINITION §2` 符号污染决策); its canonical
+  instance is a harness instruction the user has repeatedly countermanded.
+
+Answering a present-but-ignored rule with another rule is worthless; separating violation from gap
+is therefore the stage's core discrimination. *evidence:* [E2](../../experiments/E2_attribution/).
+
+## Applicability — the omission half
+
+A violation or conflict is visible because the symbol or the rejected behavior is in the trace.
+**Omission — a symbol that should have fired but didn't — is not in the trace**, so trace-reading
+cannot find it; it is reached by matching the failed episode's intent against the symbol catalog.
+That match needs an **applicability** estimate: was this symbol even relevant here? Adherence
+(执行率) is meaningful only against that denominator — a low raw firing rate over all sessions is
+not a violation if most sessions were out of scope.
+
+Applicability for skills is partly observable (invocation is a trace fact); for prose rules it is
+a semantic judgement. Without the estimate, an omission is a **review candidate, not a verdict** —
+which is the v1/v2 boundary ([maintain.md](maintain.md)). *evidence:* [E3](../../experiments/E3_applicability/).

--- a/docs/design/detect.md
+++ b/docs/design/detect.md
@@ -1,0 +1,41 @@
+# detect — observe and isolate failure episodes
+
+Upstream of all attribution. Turns raw session records into candidate *failure episodes*.
+Spine context: [workflow.md](workflow.md).
+
+## Observe
+
+Read-only ingest of session traces and repository/VCS state into normalized records. No writes,
+no network, secrets/PII redacted at the boundary. The reader is source-adapted (Claude Code
+records first; other agents via adapters) so everything downstream is source-agnostic.
+
+## Two channels, not one
+
+Detection runs two channels with different roles, set by their measured density and precision:
+
+- **Structural channel (spine).** The trace's own objective failures — tool errors, test
+  failures, build breaks, reverts. Dense and high-precision because an error in tool output is
+  ground truth. This is what surfaces candidate bad episodes at volume.
+- **Correction channel (overlay).** Explicit user corrections of agent behavior. Rare, but each
+  real one directly signals a harness gap or an unfollowed preference, so it carries
+  disproportionate value when present.
+
+The naive framing "training data = user replies" is wrong for code agents: replies are the
+grounding overlay, objective failure is the spine. *evidence:* [E1](../../experiments/E1_signal_density/).
+
+## The interrogative trap
+
+A correction detector built on negative-sentiment phrases is unusable: on a bilingual user,
+question particles collide with negation and drown real corrections in follow-up questions.
+**The correction detector must exclude interrogatives** — this single filter is the difference
+between roughly one-in-twenty and one-in-two precision, and it gates everything downstream. Phrase
+lists alone are rejected; the dependable correction signal is an imperative-directive shape, with
+an LLM classifier reserved for the candidates that survive the filter.
+*evidence:* [E2](../../experiments/E2_attribution/).
+
+## Not every failure is harness-attributable
+
+Most structural failures are normal exploratory friction (a missing file, a first test run),
+not harness defects. Detect's job is to surface candidates cheaply and at high recall; deciding
+which are harness-attributable is [attribute.md](attribute.md)'s job, run on the filtered set so
+the expensive reasoning is spent only where it can pay off.

--- a/docs/design/index.md
+++ b/docs/design/index.md
@@ -6,8 +6,20 @@ ruthlessly concise, name modules/objects not functions/paths).
 
 ## Spine
 
-- [workflow.md](workflow.md) — principle + pipeline + invariants. *(stub — fill first.)*
+- [workflow.md](workflow.md) — principle (maintain, don't grow) + the Observe→Detect→Attribute→
+  Decide→Verify→Stage pipeline + the nine cross-cutting invariants. Start here.
 
 ## Steps
 
-> Add one doc per pipeline step as it solidifies, linked here.
+- [detect.md](detect.md) — observe (read-only) and isolate failure episodes on two channels
+  (objective structural spine + user-correction overlay); the interrogative-exclusion filter.
+- [attribute.md](attribute.md) — episode → responsible symbol and the four attribution classes
+  (violation / scope-mismatch / gap / conflict); applicability and the omission half.
+- [maintain.md](maintain.md) — value map → action set, the recurrence gate on addition, the
+  per-action verify gate, the v1/v2 boundary, and staging.
+
+## Evidence
+
+The invariants rest on three measurements over real `~/.claude` records, under
+[`experiments/`](../../experiments/): E1 (signal density), E2 (attribution feasibility),
+E3 (applicability tractability).

--- a/docs/design/maintain.md
+++ b/docs/design/maintain.md
@@ -1,0 +1,62 @@
+# maintain — action, gate, and staging
+
+Turns an attributed episode into a gated, reviewable symbol edit. Spine: [workflow.md](workflow.md).
+
+## Value map → action
+
+Each symbol is valued as *relevance × gain-when-followed − resident cost (tokens + attention
+dilution + conflict)*. This is a map of what to measure, not a computable score (`DEFINITION §3`):
+per-symbol relevance, gain, and dilution are open problems, so the stage emits **evidence-backed
+action proposals, not precise rankings**. The attribution class ([attribute.md](attribute.md))
+plus the value signals select an action from the maintenance set, borrowed from Bayesian-Agent and
+extended:
+
+| Symbol condition | Action |
+|---|---|
+| high value, mechanically enforceable | **hookify** — move to a deterministic hook |
+| high value, judgement-bound | **keep** |
+| overlaps a higher-value symbol | **dedup / merge** |
+| narrower scope than the recurring need | **generalize** |
+| long relative to its value | **compress** |
+| present, applicable, ignored | **enforce** (hookify / reposition) |
+| actively produces a rejected behavior | **retire / override** |
+| never followed, no gain, pure conflict | **retire** |
+| genuine gap, recurring | **add** — last resort, behind the recurrence gate |
+| value uncertain, cheap to test | **measure** |
+
+## The recurrence gate on addition
+
+Addition is the one action that grows the layer, so it carries the strictest precondition
+(`DEFINITION §8`): a candidate symbol is added only if the episode **recurs** across many distinct
+sessions, **cannot be merged** into an existing symbol, and **passes the verify gate**. A single
+occurrence never mints a rule. Recurrence is real and measurable on history — the gap themes recur
+across dozens of sessions. *evidence:* [E2](../../experiments/E2_attribution/).
+
+## Verify — the gate per action
+
+Every change net-improves on a replay/measurement set built from the user's own history, judged by
+an **action-appropriate** criterion, preferring objective zero-oracle checks; gate strength scales
+with reversibility and blast radius:
+
+- **hookify** — deterministic migration; behavior-preservation check, no judge.
+- **dedup / compress / generalize / refactor** — behavior-no-regression on the replay set.
+- **retire / override** — adherence and the flaw's recurrence must not worsen once removed.
+- **add** — a held-out drop in the flaw's recurrence ("flaw 出现率降没降"), the benchmark-free
+  verify that needs no ground-truth labels.
+
+Where the behavior is VCS- or trace-checkable, the gate is a direct objective measurement with no
+oracle and no LLM — the strongest available evidence. *evidence:* [E3](../../experiments/E3_applicability/).
+
+## v1 / v2 boundary
+
+- **v1** acts only where firing and adherence are **objectively observable** — skill invocation
+  counts, VCS-checkable behaviors, presence, duplication, token cost. It ships dedup / compress /
+  hookify / coarse-retire as a reviewable diff plus a symbol-health view; it never replays, never
+  deep-attributes, and presents semantic omissions as candidates.
+- **v2** adds the LLM applicability estimator, trace-level attribution, and replay-based gating,
+  unlocking scope-mismatch generalization and prose-rule omission.
+
+## Stage → Adopt
+
+Output is a reviewable diff and a symbol-health view; a human adopts. Never auto-write (invariant 1).
+The dry-run / staging / consent shell is taken wholesale from SkillOpt (`DECISION.md`).

--- a/docs/design/workflow.md
+++ b/docs/design/workflow.md
@@ -1,5 +1,84 @@
 # workflow — the design spine
 
-> **TODO**: the spine of the design — the governing principle, the end-to-end pipeline, and the
-> cross-cutting invariants every step must hold. Fill this first as the architecture solidifies;
-> the per-step docs and [index.md](index.md) hang off it.
+The governing principle, the end-to-end pipeline, and the cross-cutting invariants every
+step holds. Per-step docs and [index.md](index.md) hang off this. See [`DEFINITION.md`](../DEFINITION.md)
+for product intent, [`DECISION.md`](../DECISION.md) for why the SkillOpt skeleton.
+
+## Principle
+
+**Maintain the symbol layer; do not grow it.** The harness symbol layer (CLAUDE.md / skills /
+rules / memory) is not free — it bloats, overfits, pollutes decisions, and gets ignored. The
+system closes one loop from real session outcomes to **gated, human-reviewed, never-auto-written**
+symbol edits, and the default verdict on any symbol is a *maintenance* action (enforce / merge /
+compress / generalize / retire), not addition. Addition is the last resort, behind a recurrence
+gate.
+
+## Pipeline
+
+```
+ session records          ┌────────── read-only ──────────┐
+ (~/.claude, git)  ──────► │ Observe → Detect → Attribute  │
+                          └───────────────┬───────────────┘
+                                          │ (episode, symbol, attribution-class, evidence)
+                          ┌───────────────▼───────────────┐
+                          │ Decide-action → Verify (gate)  │
+                          └───────────────┬───────────────┘
+                                          │ proposed symbol diff + health view
+                          ┌───────────────▼───────────────┐
+                          │ Stage  ──(human)──►  Adopt     │   ◄── never auto-write
+                          └───────────────────────────────┘
+```
+
+- **Observe** — read-only ingest of session traces and repository/VCS state into normalized
+  records. No writes, no network. Carries both channels Detect needs.
+- **Detect** — isolate candidate *failure episodes* on two channels: the **objective structural
+  channel** (the trace's own tool/test/build failures) as the dense, high-recall spine, and the
+  **explicit user-correction channel** as a sparse high-value overlay. Correction detection
+  excludes interrogatives before anything downstream.
+- **Attribute** — map each episode to the responsible symbol(s) and an **attribution class**:
+  *in-scope-violation* (rule present, applicable, ignored), *scope-mismatch* (rule narrower than
+  the recurring correction), *gap* (no symbol), or *conflict* (a symbol actively produces the
+  rejected behavior). Omission classes additionally require an **applicability** estimate.
+- **Decide-action** — given (symbol, class, evidence), select from the maintenance action set
+  (the value map in [maintain.md](maintain.md)). Class determines the lever: violation → enforce;
+  scope-mismatch → generalize; conflict → retire/override; gap → addition only behind the
+  recurrence gate.
+- **Verify (gate)** — every change must verifiably net-improve on a replay/measurement set built
+  from the user's own history, judged by an action-appropriate criterion, preferring objective
+  zero-oracle checks. Gate strength scales with the action's reversibility and blast radius.
+- **Stage → Adopt** — emit a reviewable diff plus a symbol-health view; a human adopts. Borrowed
+  wholesale from the SkillOpt shell (dry-run / staging / consent).
+
+## Invariants
+
+1. **Never auto-write.** Human adoption is structural grounding against self-evaluation bias, not
+   a convenience toggle. *why:* pure self-improvement dies of self-preference (`DEFINITION §2`).
+2. **Maintain, not grow.** Addition is last-resort behind the recurrence gate; the default action
+   on a symbol is maintenance. *why:* the scarce work is curation, not accumulation (`DEFINITION §3`).
+3. **Objective signal is the spine; user correction is the overlay.** Detection leads with the
+   structural failure channel; phrase-mining of corrections is rejected as primary, and any
+   correction detector excludes interrogatives. *why:* on real data the structural channel is far
+   denser and higher-precision; phrase mining is ~one-in-twenty precision on a bilingual user.
+   *evidence:* [E1](../../experiments/E1_signal_density/), [E2](../../experiments/E2_attribution/).
+4. **Attribution emits a class, and the class chooses the lever.** Violation→enforce,
+   scope-mismatch→generalize, conflict→retire, gap→gated-add. A present-but-ignored rule is never
+   answered with more text. *why:* the highest-recurrence real correction mapped to an *existing
+   ignored* rule — coverage was not the problem, adherence was.
+   *evidence:* [E2](../../experiments/E2_attribution/).
+5. **Adherence (执行率) is a first-class measured quantity.** Whether a present, applicable symbol
+   was followed is measured, not assumed. *why:* it is where the highest-value corrections land,
+   and it is the moat's numerator (`DEFINITION §7`).
+6. **Omission requires applicability; without it, output is a review candidate, not a verdict.**
+   v1 acts only where firing/adherence is objectively observable (skill invocation, VCS-checkable
+   behavior, presence/dedup/token cost); semantic applicability is a v2 estimator. *why:* raw
+   adherence rates are uninterpretable without the applicable-session denominator.
+   *evidence:* [E3](../../experiments/E3_applicability/).
+7. **Every change passes a gate; the gate prefers zero-oracle objective checks and scales with
+   risk.** Deterministic migrations (hookify) need none; deletions need adherence + flaw-rate;
+   additions need a held-out flaw-rate drop. *why:* regression discipline applied to harness
+   evolution is the benchmark-free quality definition (`research_results/benchmark-free-optimization.md`).
+8. **Keep an exploration budget.** Reserve capacity to probe symbols the loop would otherwise
+   never revisit. *why:* outcome-driven loops collapse onto familiar routines (APEX).
+9. **Observe is read-only and fails safe.** Ingest never writes, never calls the network, and
+   redacts secrets/PII at the boundary. *why:* an autonomously running maintainer must not be able
+   to harm the records it reads (`CLAUDE.md` security).

--- a/docs/plans/index.md
+++ b/docs/plans/index.md
@@ -3,4 +3,5 @@
 Working artifacts, one per non-trivial change. Exempt from the design-doc style rules. The plan's
 first unit updates the relevant `docs/design/` doc; every unit places tests before code.
 
-_(no plans yet)_
+- [roadmap.md](roadmap.md) — program-level phased execution roadmap (Phase 0 walking skeleton →
+  v1 static slice → v2 attribution+applicability → v3 breadth), each phase gated, tied to E1–E3.

--- a/docs/plans/roadmap.md
+++ b/docs/plans/roadmap.md
@@ -1,0 +1,82 @@
+# Execution roadmap — autoharness
+
+Program-level roadmap (spans many changes; working artifact, exempt from design-doc style rules).
+Expands `DEFINITION §8` into phased, gated execution. Each phase names its goal, what ships, the
+gate to advance, and the experiment evidence that de-risks it. Design is in
+[`docs/design/`](../design/index.md); the WHAT/WHY lives there, this is the WHEN/ORDER.
+
+Pinned baseline: design spine + nine invariants committed; E1–E3 measured on real `~/.claude`.
+
+---
+
+## Phase 0 — walking skeleton (the signature-conflict vertical slice)
+
+**Goal.** Run the *entire* pipeline end-to-end on the one case that is fully objective, so the
+architecture is exercised before any LLM or replay exists.
+
+**Why this case.** "commit 不要有 claude 的标识" recurs across 11 sessions, is produced by an
+explicit harness instruction (a *conflict*, not a slip), and its adherence is measurable by
+`git log` alone — zero oracle, zero LLM. It touches every stage: detect (recurring correction) →
+attribute (conflict → the instruction symbol) → decide (retire/override → hookify the user's
+preference) → verify (grep before/after) → stage (reviewable diff). *evidence:* E3.
+
+**Ships.** Observe+Detect for the correction channel (interrogative-excluded); an attributor that
+resolves this conflict to its source symbol; an action proposer that emits a hookify/override
+diff; a `git log` gate; a staged diff + a one-symbol health view. No auto-write.
+
+**Gate to advance.** The slice reproduces the measured signature persistence, proposes the hook,
+and the objective gate confirms the flaw rate would drop — reviewed and adopted by a human once.
+
+## Phase 1 — v1, the $0 static maintenance slice
+
+**Goal.** Useful maintenance with **no LLM, no replay** — only signals that are cheap and
+objectively computable (`DEFINITION §8` v1).
+
+**Ships.** Across a project's symbol layer: duplication/near-duplicate detection (dedup/merge
+candidates), token/length vs presence (compress candidates), mechanically-enforceable rules
+(hookify candidates), dormant skills and VCS-checkable behaviors (coarse retire / enforce
+candidates). Output is a reviewable diff plus the symbol-health view; everything semantic is a
+*candidate*, never a verdict (invariant 6).
+
+**Gate to advance.** On the user's own repos, v1 surfaces real dedup/hookify/retire candidates a
+human accepts, with no false "auto-fix"; the health view is legible enough to act on.
+
+**Risk watched.** v1 must not regress into a growth/extraction tool (the ECC failure mode) — it
+proposes maintenance, addition stays behind the recurrence gate.
+
+## Phase 2 — v2, attribution + applicability + replay
+
+**Goal.** Cross from objectively-observable to semantic — the moat.
+
+**Ships.** (a) the LLM **applicability estimator** (per-symbol × per-session relevance) that turns
+raw adherence proxies into real 执行率 and unlocks prose-rule omission; (b) trace-level attribution
+(borrow HarnessFix trace-IR + GEPA reflection-credit, sunk to rule granularity); (c) replay-based
+verify for behavior-no-regression on a history-built set; (d) the scope-mismatch → generalize lever.
+
+**Gate to advance.** Attribution-to-specific-rule stays stable under the estimator (re-validate the
+E2 hand result at scale); replayed edits show repairs > regressions; the applicability estimator
+is calibrated against held-out adherence the user confirms.
+
+**Open risk.** Self-preference in any judge (RHO's known weakness) — keep human adoption (invariant
+1) and prefer objective gates; treat LLM judge scores as advisory.
+
+## Phase 3 — breadth and credibility
+
+**Goal.** Generalize and prove.
+
+**Ships.** Source adapters beyond Claude Code (Codex, others); a SWE-bench + auto-harness
+*demo* purely for credibility (not a daily judge, `DEFINITION §5`); the symbol-health dashboard as
+the distribution surface; an explicit exploration budget against routine collapse (invariant 8, APEX).
+
+---
+
+## Cross-phase discipline
+
+- Each phase follows the task lifecycle (`CLAUDE.md`): plan → docs → tests → code → verify → gate.
+- New empirical claims are measured under `experiments/` before they enter a doc, linked as
+  `evidence:`. The next measurements due: detection-precision of the interrogative filter at scale,
+  and applicability-estimator calibration (both Phase 2 entry criteria) — tracked in
+  [`docs/TODO.md`](../TODO.md).
+- The competitive time-window (`DEFINITION §9`: ECC could add a gate) argues for shipping Phase 0–1
+  visibly and early; the moat (Phase 2) is what no one else has, but it only matters if the shell
+  exists to carry it.

--- a/experiments/E1_signal_density/measure_signals.py
+++ b/experiments/E1_signal_density/measure_signals.py
@@ -1,0 +1,156 @@
+"""E1 — signal-density measurement over a user's real ~/.claude records.
+
+Quantifies three candidate "the session went badly" signals so the architecture
+can choose its primary outcome channel on evidence, not assumption:
+
+  1. user-phrase corrections in history.jsonl   (SkillOpt's heuristic, as-is)
+  2. user-phrase corrections in transcripts      (bilingual + turn-adjacency)
+  3. structural tool/test/build failures         (objective, in the trace)
+
+Read-only. No network. Prints a table; commit the printed numbers into results.md.
+"""
+from __future__ import annotations
+
+import glob
+import json
+import os
+
+NEG_HISTORY = (
+    "still broken", "still not", "still wrong", "doesn't work", "does not work",
+    "not working", "that's wrong", "thats wrong", "incorrect", " wrong", "no,",
+    "nope", "fix it", "didn't", "did not", "broken", "error again", "still failing",
+    "still fails", "not fixed", "revert", "undo",
+)
+POS = ("thanks", "thank you", "perfect", "great", "works now", "fixed",
+       "that works", "lgtm", "looks good", "correct")
+
+NEG_EN = ["still broken", "still not", "doesn't work", "does not work", "not working",
+          "that's wrong", "thats wrong", "that is wrong", "incorrect", "fix it",
+          "didn't work", "did not work", "error again", "still failing", "still fails",
+          "not fixed", "revert", "undo", "that broke", "you broke", "no that",
+          "not what i", "that's not", "thats not", "wrong ", "actually no", "instead of"]
+NEG_ZH = ["还是不行", "不对", "不行", "错了", "没用", "报错", "又错", "还是有问题",
+          "不是这", "别这", "不要这", "重新", "为什么还", "怎么还", "没解决", "失败",
+          "回滚", "撤销", "改回"]
+NEG_TRANSCRIPT = NEG_EN + NEG_ZH
+
+TOOL_ERR_MARKERS = ("error", "exception", "traceback", "failed", "fatal:",
+                    "no such file", "command not found", "not found", "cannot",
+                    "permission denied", "test failed", "assertionerror",
+                    "fail ", "npm err")
+
+
+def _text(content) -> str:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return "\n".join(
+            str(b.get("text", "")) for b in content
+            if isinstance(b, dict) and b.get("type") == "text"
+        )
+    return ""
+
+
+def _is_meta(t: str) -> bool:
+    return t.startswith("<") or t.startswith("/") or t.startswith("[Pasted")
+
+
+def measure_history(path: str) -> dict:
+    n = neg = pos = meta = 0
+    for line in open(path, encoding="utf-8"):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            r = json.loads(line)
+        except Exception:
+            continue
+        d = (r.get("display") or "").strip()
+        n += 1
+        if d.startswith("/") or (d.startswith("<") and d.endswith(">")):
+            meta += 1
+            continue
+        low = d.lower()
+        if any(p in low for p in NEG_HISTORY):
+            neg += 1
+        if any(p in low for p in POS):
+            pos += 1
+    return {"prompts": n, "meta": meta, "neg": neg, "pos": pos}
+
+
+def measure_transcripts(root: str) -> dict:
+    files = glob.glob(root + "/**/*.jsonl", recursive=True)
+    sess = sess_corr = sess_toolerr = 0
+    user_turns = corr = adj_corr = tool_uses = tool_errs = 0
+    for f in files:
+        last_role = None
+        saw_turn = saw_tool = had_corr = had_err = False
+        try:
+            for line in open(f, encoding="utf-8"):
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    r = json.loads(line)
+                except Exception:
+                    continue
+                m = r.get("message")
+                if not isinstance(m, dict):
+                    continue
+                role = m.get("role")
+                content = m.get("content")
+                if role == "user":
+                    t = _text(content).strip()
+                    if t and not _is_meta(t):
+                        saw_turn = True
+                        user_turns += 1
+                        if any(p in t.lower() for p in NEG_TRANSCRIPT):
+                            corr += 1
+                            had_corr = True
+                            if last_role == "assistant":
+                                adj_corr += 1
+                if isinstance(content, list):
+                    for b in content:
+                        if not isinstance(b, dict):
+                            continue
+                        if b.get("type") == "tool_use":
+                            tool_uses += 1
+                            saw_tool = True
+                        if b.get("type") == "tool_result":
+                            cont = b.get("content")
+                            txt = cont if isinstance(cont, str) else "\n".join(
+                                str(x.get("text", "")) for x in cont
+                                if isinstance(x, dict)
+                            ) if isinstance(cont, list) else ""
+                            if b.get("is_error") or any(k in txt.lower() for k in TOOL_ERR_MARKERS):
+                                tool_errs += 1
+                                had_err = True
+                if role in ("user", "assistant"):
+                    last_role = role
+        except Exception:
+            pass
+        if saw_turn:
+            sess += 1
+        if had_corr:
+            sess_corr += 1
+        if saw_tool and had_err:
+            sess_toolerr += 1
+    return {
+        "sessions": sess, "user_turns": user_turns, "corr": corr,
+        "adj_corr": adj_corr, "sess_corr": sess_corr, "tool_uses": tool_uses,
+        "tool_errs": tool_errs, "sess_toolerr": sess_toolerr,
+    }
+
+
+if __name__ == "__main__":
+    home = os.path.expanduser("~/.claude")
+    h = measure_history(os.path.join(home, "history.jsonl"))
+    t = measure_transcripts(os.path.join(home, "projects"))
+    print("== history.jsonl (phrase, flat) ==")
+    print(h, f"neg={100*h['neg']/max(h['prompts'],1):.1f}%")
+    print("== transcripts (phrase, bilingual+adjacency) ==")
+    print(t)
+    print(f"  corr={100*t['corr']/max(t['user_turns'],1):.1f}% of user turns; "
+          f"sessions_with_corr={100*t['sess_corr']/max(t['sessions'],1):.0f}%")
+    print(f"  tool_err={100*t['tool_errs']/max(t['tool_uses'],1):.1f}% of tool calls; "
+          f"sessions_with_tool_err={100*t['sess_toolerr']/max(t['sessions'],1):.0f}%")

--- a/experiments/E1_signal_density/results.md
+++ b/experiments/E1_signal_density/results.md
@@ -1,0 +1,49 @@
+# E1 — signal-density reality check
+
+**Question.** The thesis (`DEFINITION.md §4`) starts from "收集错误/纠错(error = 用户不满)".
+Before designing the harvest stage, measure: *does that signal actually exist at usable
+density in real records, and is phrase-matching a viable detector?*
+
+**Method.** `measure_signals.py` over one real user's `~/.claude` (4267 history prompts,
+684 sessions with user turns, 17.7k tool calls). Read-only. Three candidate signals.
+
+## Measurements
+
+| Signal | Detector | Density | Eyeballed precision |
+|---|---|---|---|
+| User correction (flat) | SkillOpt phrase list, `history.jsonl` | **0.1%** of prompts (5/4267) | ~0 (FPs: a question, an index row, a pasted error) |
+| User correction (context) | bilingual phrases + assistant→user adjacency, transcripts | **3.3%** of user turns; **11%** of sessions | <30% (interrogatives "要不要/怎么还", pasted errors dominate) |
+| **Structural failure** | tool_result `is_error` / error markers in trace | **20.8%** of tool calls; **65%** of sessions | high — an error in tool output is ground truth, not a guess |
+
+## Findings
+
+1. **Phrase-matching for corrections is not viable as the primary channel.** On flat
+   prompt text it is 0.1% with near-zero precision; with bilingual phrases and turn
+   adjacency it rises to 11% of sessions but precision stays low — questions and pasted
+   error text swamp real corrections. This quantifies the doc's hedge (`DECISION.md`:
+   "不直接继承关键词判据,太浅") with a number.
+
+2. **The objective structural signal is ~6× denser at the session level (65% vs 11%) and
+   far higher precision.** This is the one domain advantage `DEFINITION.md §6` bets on
+   ("code 是唯一天然有客观判据") showing up in the raw data.
+
+3. **But raw tool errors are mostly normal exploratory friction, not harness defects**
+   (grep misses, file-not-yet-created, first-test-fail-then-pass). 20.8% is the *failure*
+   rate, not the *harness-attributable* rate. The attributable subset is much smaller and
+   needs an attribution step to isolate (→ E2).
+
+## Design implication (feeds `docs/design/`)
+
+The outcome channel is **two-tier, not user-reply-primary**:
+
+- **Wide net — objective structural failure** (dense, cheap, high-recall): the trace's own
+  tool/test/build errors. This is what surfaces *candidate* bad episodes at volume.
+- **Sparse high-value overlay — explicit user correction** (rare, but when real it directly
+  signals a harness gap, e.g. "为什么还是英文" = an unfollowed preference). Too sparse and
+  low-precision for phrase-matching to be the spine; worth an LLM classifier on the
+  adjacency-filtered candidates, not a keyword pass.
+
+Corollary: the naive reading "training data = mainly user replies" is **wrong for code
+agents**. User replies are the grounding overlay; objective failure is the spine.
+
+evidence-for: harvest stage primary signal = structural failure, not phrase mining.

--- a/experiments/E2_attribution/extract_and_attribute.py
+++ b/experiments/E2_attribution/extract_and_attribute.py
@@ -1,0 +1,96 @@
+"""E2 — rule-level attribution feasibility (DEFINITION.md §8 hard point 1).
+
+Two stages over real transcripts:
+  1. detect behavioral corrections — imperative directives, NOT questions
+     (the interrogative-exclusion filter is the precision lever E1/E2 found).
+  2. theme recurrence — count how often each correction theme recurs across
+     distinct sessions (the 增长闸 recurrence test needs real numbers).
+
+Hand-attribution of the detected corrections to specific CLAUDE.md symbols is
+recorded in results.md (a human judgement step, not automated here).
+Read-only.
+"""
+from __future__ import annotations
+
+import glob
+import json
+import os
+
+CORR_MARKERS = ["不要", "别用", "别再", "不是这", "不应该", "应该先", "下次", "记住",
+                "以后", "always", "never", "don't", "do not", "stop ", "你应该",
+                "你不该", "不用", "错了", "写错", "搞错"]
+QUESTION_MARKERS = ["吗", "呢", "区别", "怎么", "为什么", "是不是", "究竟", "?", "？",
+                    "哪个", "几个", "多少", "如何", "what", "how ", "why ", "which"]
+
+THEMES = {
+    "verbosity/fluff": ["废话", "太多了", "太长", "简洁", "精简", "不用教", "啰嗦",
+                        "冗长", "too long", "too verbose", "more concise"],
+    "format/markdown": ["markdown", "不要格式", "plain text", "纯文本", "别用markdown"],
+    "tone/persona": ["不要带语气", "正常回答", "别夸", "客观", "tone", "语气"],
+    "no-fabrication": ["不要编造", "别编", "不要强行", "没有依据", "没有参考", "凭空",
+                       "胡编", "made up", "fabricat"],
+    "claude-signature": ["cluade的标识", "claude的标识", "co-author", "claude标识",
+                         "别带claude", "签名", "signature"],
+    "dont-duplicate": ["完全引用", "不要单独阐述", "不要重复", "交叉引用",
+                       "其他地方也一样", "cross-reference", "don't duplicate"],
+}
+
+
+def _text(c) -> str:
+    if isinstance(c, str):
+        return c
+    if isinstance(c, list):
+        return "\n".join(str(b.get("text", "")) for b in c
+                         if isinstance(b, dict) and b.get("type") == "text")
+    return ""
+
+
+def _is_correction(t: str) -> bool:
+    low = t.lower()
+    if not any(p in low for p in CORR_MARKERS):
+        return False
+    has_q = any(q in t for q in QUESTION_MARKERS)
+    has_imperative = ("不要" in t or "别" in t or "don't" in low or "do not" in low)
+    return has_imperative or not has_q
+
+
+def run(root: str) -> None:
+    files = glob.glob(root + "/**/*.jsonl", recursive=True)
+    corrections = []
+    theme_turns = {k: 0 for k in THEMES}
+    theme_sess = {k: set() for k in THEMES}
+    for f in files:
+        sid = os.path.basename(f)
+        prev = ""
+        for line in open(f, encoding="utf-8"):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                r = json.loads(line)
+            except Exception:
+                continue
+            m = r.get("message")
+            if not isinstance(m, dict):
+                continue
+            role = m.get("role")
+            t = _text(m.get("content")).strip()
+            if role == "assistant" and t:
+                prev = t
+            elif role == "user" and t and not (t.startswith("<") or t.startswith("/")
+                                               or t.startswith("[Pasted")):
+                if _is_correction(t) and len(t) < 240 and prev:
+                    corrections.append((sid, prev[-160:], t[:230]))
+                for k, phr in THEMES.items():
+                    if any(p.lower() in t.lower() for p in phr) and _is_correction(t):
+                        theme_turns[k] += 1
+                        theme_sess[k].add(sid)
+                prev = ""
+    print(f"behavioral corrections detected: {len(corrections)}")
+    print("\ntheme                 turns  distinct_sessions")
+    for k in THEMES:
+        print(f"  {k:18s}  {theme_turns[k]:4d}   {len(theme_sess[k])}")
+
+
+if __name__ == "__main__":
+    run(os.path.expanduser("~/.claude/projects"))

--- a/experiments/E2_attribution/results.md
+++ b/experiments/E2_attribution/results.md
@@ -1,0 +1,70 @@
+# E2 — rule-level attribution feasibility
+
+**Question (`DEFINITION.md §8` hard point 1).** "拿自己 5 条真实纠错手验'能否稳定归到
+具体规则'。归不准,整条线塌。" Can a real correction be stably attributed to a *specific*
+symbol, and does that attribution drive a clean action choice?
+
+**Method.** Detect behavioral corrections in real transcripts (imperative directive, not
+question), then hand-attribute each against the actual symbol layer (`lara/CLAUDE.md`,
+`autoharness/CLAUDE.md`, project skills). 63 corrections detected across all projects.
+
+## Precondition finding: detection precision gates everything
+
+| Correction detector | precision (sampled) |
+|---|---|
+| phrase list, any match | ~5% — Chinese interrogatives (还是/为什么/区别/是不是) collide with neg phrases |
+| phrase list **minus question markers** | ~50%+ |
+
+The dominant failure mode upstream of attribution is **not** mis-attribution — it is
+mis-*detection*: questions read as corrections. **An interrogative-exclusion filter is
+mandatory; phrase mining alone is unusable.** (Confirms & sharpens E1.)
+
+## Hand-attribution of real corrections
+
+| # | Real user correction (verbatim, trimmed) | Attributed symbol | Outcome class | Action |
+|---|---|---|---|---|
+| C14 | "不要有任何废话…一个表给人验证" | CLAUDE.md *"design docs ruthlessly concise, no filler"* | **scope-mismatch** — rule exists but scoped to design docs; correction is about a runbook | broaden scope |
+| C15 | "改成完全引用Taxonomy 不要在这里单独阐述 其他地方也一样" | CLAUDE.md *"one authoritative source / cross-reference"* | **in-scope violation** — rule present, not followed | enforce (low adherence) |
+| C20 | "不要自己定义没有参考依据的东西" | CLAUDE.md *"verify empirical claims before asserting"* | **in-scope violation** | enforce |
+| C13 | "不要打分 在初步idea" | project skill's *no-aggregation* rule | **in-scope violation** | enforce |
+| C0 | "不要带语气 就正常回答问题" | — none — | **gap** | candidate add (recurs ×25 sessions) |
+| C2 | "不要markdown格式" | — none — | **gap** | candidate add |
+| C3 | "写的太多了…其他的 it 都知道" | — none (broad concision) — | **gap / scope-mismatch** | candidate add (recurs ×27) |
+| C1 | "commit 不要有 cluade 的标识" | — none — | **gap** | candidate add (recurs ×11) |
+| C6 | "不要编造 做不到就不要强行凑" | — none — | **gap** | candidate add (recurs ×24) |
+
+## Findings
+
+1. **Attribution to a specific symbol is feasible** — every correction resolved to either
+   a named existing symbol or a confident "no symbol". The make-or-break hard point passes,
+   **conditional on** the detection filter above. 归得准。
+
+2. **Attribution is not binary. Three outcome classes, each a different action** — this
+   refines the chat-level "violation vs gap" dichotomy:
+   - **in-scope violation** (C15, C20, C13): rule exists, applies, ignored → the lever is
+     *adherence/enforcement* (hookify · reposition earlier · compress competing noise),
+     **not** adding text. Writing another rule the agent already ignores is worthless.
+   - **scope-mismatch** (C14, C3): a rule covers a narrower scope than the recurring
+     correction → *generalize/broaden* the existing symbol, do not add a sibling.
+   - **gap** (C0, C2, C1, C6): no symbol → *candidate addition*, gated by recurrence (§8).
+
+3. **Recurrence (the 增长闸 input) is real and measurable.** The gap themes recur across
+   many distinct sessions — tone ×25, verbosity ×27, no-fabrication ×24, markdown ×27,
+   commit-signature ×11. A single occurrence must NOT mint a rule; these clear any
+   reasonable threshold.
+
+4. **The most striking case is the in-scope violation.** A "ruthlessly concise / no filler"
+   rule is *already in CLAUDE.md*, yet verbosity is the single most recurring correction.
+   Direct evidence that the bottleneck is **adherence (执行率), not coverage** — the §7 moat.
+   More text would not have helped; this rule needed enforcement or repositioning.
+
+## Implications (feed `docs/design/`)
+
+- Detection stage MUST filter interrogatives before anything downstream (cheap, decisive).
+- The attribution stage emits one of {in-scope-violation, scope-mismatch, gap}, and the
+  action set branches on that class — the dichotomy in the chat answer was too coarse.
+- Adherence (did a present, applicable rule get followed?) is a first-class measured
+  quantity, not a derived afterthought — it is where the highest-recurrence corrections land.
+
+evidence-for: attribution stage outcome taxonomy; adherence-as-primary-lever; detection
+must exclude questions.

--- a/experiments/E3_applicability/probe.py
+++ b/experiments/E3_applicability/probe.py
@@ -1,0 +1,98 @@
+"""E3 — applicability / omission tractability probe (DEFINITION.md §7 造0, the 共同盲区).
+
+Omission = "a symbol should have fired but didn't". Decompose into:
+    执行率 (adherence) = fired_and_applicable / applicable
+The numerator's "fired" is observable for SKILLS (invocation is a fact in the
+trace); the denominator "applicable" is a semantic judgement. This probe maps
+which half is structurally tractable without an LLM, on real data.
+
+Three measurements:
+  1. skill dormancy        — distinct skills invoked vs available (numerator side)
+  2. rule-adherence proxy  — worktree/TDD usage rate, to expose the denominator trap
+  3. objective adherence   — Claude commit-signature persistence vs a recurring
+     user correction (the one case fully measurable with zero LLM)
+Read-only except (3) shells out to `git log` on sibling repos.
+"""
+from __future__ import annotations
+
+import glob
+import json
+import os
+import re
+import subprocess
+
+
+def _text(c) -> str:
+    if isinstance(c, str):
+        return c
+    if isinstance(c, list):
+        return " ".join(str(b.get("text", "")) for b in c
+                        if isinstance(b, dict) and b.get("type") == "text")
+    return ""
+
+
+def skill_and_adherence(root: str) -> None:
+    skill_calls: dict = {}
+    sess = wt = test = code = 0
+    for f in glob.glob(root + "/**/*.jsonl", recursive=True):
+        saw = used_wt = wrote_test = wrote_code = False
+        for line in open(f, encoding="utf-8"):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                r = json.loads(line)
+            except Exception:
+                continue
+            m = r.get("message")
+            if not isinstance(m, dict):
+                continue
+            c = m.get("content")
+            if isinstance(c, list):
+                for b in c:
+                    if not isinstance(b, dict) or b.get("type") != "tool_use":
+                        continue
+                    saw = True
+                    nm, inp = b.get("name", ""), b.get("input", {}) or {}
+                    if nm == "Skill":
+                        s = inp.get("skill") or inp.get("command") or "?"
+                        skill_calls[s] = skill_calls.get(s, 0) + 1
+                    if "worktree" in json.dumps(inp).lower():
+                        used_wt = True
+                    if nm in ("Write", "Edit"):
+                        p = str(inp.get("file_path", ""))
+                        if re.search(r"test_.*\.py$|/tests?/|\.test\.|\.spec\.", p):
+                            wrote_test = True
+                        elif p.endswith((".py", ".ts", ".tsx", ".js", ".go", ".rs")):
+                            wrote_code = True
+        if saw:
+            sess += 1
+            wt += used_wt
+            test += wrote_test
+            code += wrote_code
+    print(f"distinct skills ever invoked: {len(skill_calls)}  {dict(sorted(skill_calls.items(), key=lambda x:-x[1]))}")
+    print(f"sessions(tool)={sess}  worktree={wt} ({100*wt//max(sess,1)}%)  "
+          f"test={test} ({100*test//max(sess,1)}%)  code={code} ({100*code//max(sess,1)}%)")
+    print("  -> raw adherence % is uninterpretable: denominator (applicable sessions) unknown")
+
+
+def signature_adherence(projects_root: str, repos: list) -> None:
+    print("\nClaude commit-signature persistence (objective, zero-LLM):")
+    for d in repos:
+        path = os.path.join(projects_root, d)
+        if not os.path.isdir(os.path.join(path, ".git")):
+            continue
+        bodies = subprocess.run(
+            ["git", "-C", path, "log", "-200", "--format=%b"],
+            capture_output=True, text=True).stdout
+        sig = len(re.findall(r"(?i)co-authored-by: claude|generated with.*claude", bodies))
+        n = len(subprocess.run(["git", "-C", path, "log", "--oneline", "-200"],
+                               capture_output=True, text=True).stdout.splitlines())
+        print(f"  {d:16s} {sig}/{n} signed")
+
+
+if __name__ == "__main__":
+    skill_and_adherence(os.path.expanduser("~/.claude/projects"))
+    signature_adherence(os.path.expanduser("~/tigerless_ai"),
+                        ["lara", "livins", "context-xray", "cost-xray",
+                         "ai_translation", "harness-tax", "autoharness"])

--- a/experiments/E3_applicability/results.md
+++ b/experiments/E3_applicability/results.md
@@ -1,0 +1,63 @@
+# E3 — applicability / omission tractability
+
+**Question (`DEFINITION.md §7` 造0, the 共同盲区).** Omission = "a symbol should have fired
+but didn't". Can we detect it? The named moat is 适用性推断 — the *denominator* of
+执行率 = fired_and_applicable / applicable.
+
+## Measurements
+
+1. **Skill firing is observable; most skills are dormant.** Only **6 distinct skills** were
+   ever invoked via the Skill tool across 653 tool-using sessions (top: last30days ×12,
+   claude-api ×6). Dozens of available skills fired zero times.
+
+2. **Raw adherence proxies are uninterpretable.** Worktree usage 6% of sessions, test-file
+   writes 6%, in projects that *mandate* worktree-per-task + TDD. This is **not** 94%
+   violation: most sessions are Q&A/exploration (see E2) where those rules don't apply. The
+   raw rate without the applicability denominator is **meaningless** — and computing the
+   denominator ("was this a non-trivial code change in a mandating project?") is a semantic
+   judgement.
+
+3. **One gap is fully objective.** "commit 不要有 claude 的标识" (E2 C1, recurs ×11 sessions)
+   is measurable with `git log` alone — no LLM:
+
+   | repo | signed / last-200 |
+   |---|---|
+   | lara | 86/121 | livins | 83/200 | context-xray | 35/44 |
+   | cost-xray | 13/21 | ai_translation | 11/13 | harness-tax | 9/15 |
+
+   ~70% persistence **including this experiment's own commits**.
+
+## Findings
+
+1. **Omission factorizes into observable × semantic.** "Did it fire?" is structurally
+   observable for *skills* (invocation is a trace fact), fuzzy for *prose rules* (always
+   in-context, so "fired" ≠ "followed"). "Should it have?" (applicability) is semantic for
+   both. **The moat's denominator is the genuinely hard half** — confirmed, not solved.
+
+2. **v1/v2 split falls straight out of this.** Without an LLM you can surface *dormant
+   skills* and *raw proxies* as **review candidates** — never as confident omission verdicts
+   (the denominator is missing). True omission detection (per-(symbol,session) applicability)
+   needs the v2 LLM judge. This matches §8 "v1 给动作建议+证据,不给精确分数".
+
+3. **The signature case is the canonical worked example for the whole system** — and it is
+   richer than "gap":
+   - The agent signs because an **explicit harness instruction tells it to** ("End git
+     commit messages with: Co-Authored-By: Claude…"). So this is **not** an adherence slip —
+     it is a **harness symbol actively producing a user-rejected behavior** = `DEFINITION §2`
+     "符号污染决策", the thesis in one case.
+   - Attribution target = that instruction symbol; correct action = **retire/override it**
+     (or hookify the user's preference so it wins), not add a rule.
+   - Gate = `grep` git log before/after. **Zero-oracle, zero-LLM verification** — exactly the
+     "flaw 出现率降没降" verify the docs prize, available for free here.
+
+## Implication
+
+- v1 acts only where firing/adherence is **objectively observable** (skill invocation counts,
+  git-checkable behaviors like the signature, presence/dedup/token cost). It presents
+  everything else as review candidates.
+- v2 adds the applicability estimator (LLM per-(symbol,session)) that turns raw adherence
+  proxies into real 执行率, unlocking prose-rule omission.
+- Feature the **commit-signature conflict** as the design's worked example end-to-end.
+
+evidence-for: v1 = objectively-observable actions only; applicability estimator is v2;
+conflict (symbol-vs-user) is a first-class attribution outcome alongside violation/gap.


### PR DESCRIPTION
Completes the architecture design and execution roadmap in **research mode** — every
load-bearing claim is measured on real `~/.claude` records first, not asserted.

## Experiments (under `experiments/`, reproducible scripts + results)

- **E1 — signal density.** Structural tool/test failures appear in **65% of sessions**
  vs **11%** (low-precision) for phrase-mined corrections. → primary outcome channel is
  *objective failure*, not user replies. Corrects the naive "training data = user replies".
- **E2 — attribution feasibility** (`DEFINITION §8` hard point 1). Attribution to a
  *specific* symbol works — **conditional on excluding interrogatives** in detection
  (~5% → ~50% precision on a bilingual user). Yields four attribution classes:
  in-scope-violation / scope-mismatch / gap / conflict. The highest-recurrence real
  correction (verbosity) maps to an **existing, ignored** rule → the lever is *adherence,
  not coverage*.
- **E3 — applicability tractability** (the §7 common blind spot). Omission factorizes into
  *observable(fired?) × semantic(applicable?)*; the applicability denominator is the hard
  half → v1 acts only on objectively-observable behavior, v2 adds the LLM estimator. The
  **commit-signature conflict** ("no claude signature", recurs ×11, ~70% persistence including
  this PR's own commits) is the canonical worked example — gateable by `grep`, zero-oracle.

## Architecture (`docs/design/`)

`workflow.md` spine (principle: *maintain, don't grow*; Observe→Detect→Attribute→Decide→
Verify→Stage pipeline; nine invariants with `evidence:` pointers) + `detect.md` /
`attribute.md` / `maintain.md`. Invariants indexed into `CLAUDE.md`.

## Roadmap (`docs/plans/roadmap.md`)

Phase 0 walking skeleton (signature-conflict vertical slice) → v1 $0 static slice →
v2 attribution+applicability+replay → v3 breadth. Each phase gated, tied to E1–E3.

## Flags for review
- **Live conflict, not auto-resolved (invariant 1).** The harness instruction to add
  `Co-Authored-By: Claude` conflicts with your repeated correction (×11). I kept signing for
  session consistency and logged it in `docs/TODO.md` rather than unilaterally applying a
  mined preference — human-in-the-loop is the thesis. Your call on retire vs hookify-override.
- Phase-2 entry measurements (filter precision at scale, applicability calibration) are open
  TODOs.
