### PR TITLE
docs: agent-skill / meta-skill / harness paper collection (2026-06-22)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -22,4 +22,5 @@ only points. Keep it current when files are added, moved, or removed.
 ## Research
 
 - [research_results/](research_results/index.md) — compressed landscape findings (research notes,
-  not design docs).
+  not design docs). Includes [research_results/papers/](research_results/papers/index.md) — the
+  per-paper collection on agent skills, meta-skills & harness evolution.

--- a/docs/research_results/index.md
+++ b/docs/research_results/index.md
@@ -17,6 +17,9 @@ Reference lists:
 - [paper-list.md](paper-list.md) — all referenced papers, grouped by theme, with arXiv links
 - [github-list.md](github-list.md) — all referenced repos, grouped, with star counts
 
+Paper collections (per-paper deep reads, added later):
+- [papers/](papers/index.md) — agent skills, meta-skills & harness evolution (2026-06-22 batch, 13 sources)
+
 **One-line takeaway for autoharness's positioning:** the contested, low-competition
 gap is *benchmark-free, trajectory-bootstrapped harness evolution with audit/gate/rollback* —
 distinct from governance frameworks, fuzz-harness generation, and benchmark-requiring optimizers.

--- a/docs/research_results/papers/agent-skill-eval-survey.md
+++ b/docs/research_results/papers/agent-skill-eval-survey.md
@@ -1,0 +1,13 @@
+# Agent Skill Evaluation and Evolution — survey
+
+**Ding, Zhou, Jin, Tong, Zhou, Metaxas** — "Agent Skill Evaluation and Evolution: Frameworks and Benchmarks" ([arXiv:2606.11435](https://arxiv.org/abs/2606.11435), 2026-06). Code/list: [Cassie07/AgentSkill_Survey](https://github.com/Cassie07/AgentSkill_Survey).
+
+Survey consolidating the shift from "isolated skill creation to automated, evaluation-driven skill evolution."
+
+Two taxonomies:
+- **Four evolution paradigms** — execution feedback, trajectory distillation, compression, reinforcement learning.
+- **Six skill-centric benchmark categories** — with the paper flagging structural gaps in coverage, trade-offs, and metric richness.
+
+Open direction: skill ecosystems that are generalizable, efficient, and *verifiably safe*.
+
+**Relevance to autoharness:** the evaluation half is the live question for any harness optimizer — how to measure skill/harness utility without overfitting a benchmark. Pairs with [../benchmark-free-optimization.md](../benchmark-free-optimization.md). A companion reading list for cross-checking the cluster.

--- a/docs/research_results/papers/claude-code-skills.md
+++ b/docs/research_results/papers/claude-code-skills.md
@@ -1,0 +1,18 @@
+# Lessons from building Claude Code — how we use skills
+
+**Thariq Shihipar, Anthropic** — "Lessons from building Claude Code: How we use skills" ([claude.com blog](https://claude.com/blog/lessons-from-building-claude-code-how-we-use-skills), 2026-06).
+
+Practitioner counterpart to the academic cluster. Skills are folders (instructions + scripts + assets + data), not "just markdown"; the best ones serve a single clear purpose — broad ones "straddle several and confuse the agent."
+
+Nine internal skill categories: library/API reference, **product verification** (the most measurable quality impact), data fetching/analysis, business-process automation, scaffolding/templates, code quality/review, CI/CD, runbooks, infra operations.
+
+Design lessons that transfer to harness/skill authoring:
+- Don't state the obvious — target what pushes the model off its default behavior.
+- The **Gotchas section is the highest-signal content** in any skill.
+- File system + progressive disclosure: SKILL.md points to other files read on demand.
+- Avoid railroading; give information plus room to adapt.
+- The description is a **trigger spec for the model**, not a human summary.
+- Persist data/logs; store scripts so the model spends turns on composition, not boilerplate.
+- Most strong skills "began as a few lines and a single gotcha," then grew from real edge cases.
+
+**Relevance to autoharness:** ground truth on what a maintained skill/harness document looks like in production, and on iterative, failure-driven refinement — the loop autoharness automates.

--- a/docs/research_results/papers/embodiskill.md
+++ b/docs/research_results/papers/embodiskill.md
@@ -1,0 +1,9 @@
+# EmbodiSkill — skill-aware reflection for embodied agents
+
+**Ju, Wang, Ding, Yang, … Cao (15 authors)** — "EmbodiSkill: Skill-Aware Reflection for Self-Evolving Embodied Agents" ([arXiv:2605.10332](https://arxiv.org/abs/2605.10332), 2026-05).
+
+Problem: embodied agents must evolve skills from their own trajectories, but digital-domain methods give "coarse skill updates," and a failed task is ambiguous — it may reflect **flawed skill content** *or* an **execution lapse** (agent ignored valid guidance). EmbodiSkill is a training-free framework that disambiguates: interpret each trajectory against the current skill, use *skill-changing* evidence to revise the skill body, and use *execution-lapse* evidence to preserve and emphasize the guidance that was already correct.
+
+Results: ALFWorld + EmbodiedBench — consistent success gains. On ALFWorld a frozen Qwen3.5-27B executor reaches **93.28%**, beating GPT-5.2 used directly (no skills) by 31.58%.
+
+**Relevance to autoharness:** the **"bad skill vs. ignored skill" distinction** is the crucial attribution guardrail — autoharness must not rewrite a harness rule that failed only because it was never followed (cf. SkillEvolver's silent-bypass audit). Embodied setting, but the attribution logic is domain-general.

--- a/docs/research_results/papers/externalization-review.md
+++ b/docs/research_results/papers/externalization-review.md
@@ -1,0 +1,15 @@
+# Externalization in LLM Agents — a unified review
+
+**Zhou, Chai, Chen, … Lin, Zhang (21 authors)** — "Externalization in LLM Agents: A Unified Review of Memory, Skills, Protocols and Harness Engineering" ([arXiv:2604.08224](https://arxiv.org/abs/2604.08224), 2026-04, 54pp).
+
+The umbrella survey for this whole collection. Thesis: modern agents are built "less by changing model weights than by reorganizing the runtime around them" — capability is **externalized** into infrastructure (the cognitive-artifacts framing), tracing a progression *weights → context → harness*.
+
+Four coupled forms of externalization:
+- **Memory** — externalizes state across time.
+- **Skills** — externalizes procedural expertise.
+- **Protocols** — externalizes interaction structure.
+- **Harness engineering** — the *unification layer* that coordinates the other three into governed execution.
+
+Key claims: infrastructure isn't glue — it "transforms hard cognitive burdens into forms the model can solve more reliably"; the parametric-vs-externalized trade-off is the central design axis; emerging frontier is **self-evolving harnesses and shared agent infrastructure**, with open problems in evaluation, governance, and model–infrastructure co-evolution.
+
+**Relevance to autoharness:** names the harness as a first-class engineering concern and the coordinating layer — direct vocabulary for positioning autoharness as a *self-evolving harness*. Use as the framing citation.

--- a/docs/research_results/papers/index.md
+++ b/docs/research_results/papers/index.md
@@ -1,0 +1,43 @@
+# Paper collection — agent skills, meta-skills & harness evolution (2026-06-22)
+
+A focused reading list shared 2026-06-22: the April–June 2026 wave on **externalized skills,
+meta-skills, and self-evolving harnesses**. One file per source; each is a standalone summary
+(core problem · method · results · relevance to autoharness). Links are arXiv submission pages
+and, where released, code.
+
+This is a *deeper, per-paper* read that complements the prior compressed landscape in
+[../index.md](../index.md) — overlaps (e.g. MUSE-Autoskill) are cross-linked, not duplicated.
+
+## A. Framing, surveys & infrastructure
+
+1. [externalization-review.md](externalization-review.md) — *Externalization in LLM Agents* ([2604.08224](https://arxiv.org/abs/2604.08224)). The umbrella survey: memory/skills/protocols/**harness** as the four externalized layers; harness = the unification layer.
+2. [agent-skill-eval-survey.md](agent-skill-eval-survey.md) — *Agent Skill Evaluation and Evolution* ([2606.11435](https://arxiv.org/abs/2606.11435), [code](https://github.com/Cassie07/AgentSkill_Survey)). Four evolution paradigms; six benchmark categories; the evaluation-gap map.
+3. [skillwiki.md](skillwiki.md) — *SkillWiki* ([2606.16523](https://arxiv.org/abs/2606.16523), [code](https://github.com/Huangdingcheng/SkillWiki)). Wiki-style infrastructure for skill production, governance, and provenance-aware evolution.
+4. [claude-code-skills.md](claude-code-skills.md) — *Lessons from building Claude Code* ([blog](https://claude.com/blog/lessons-from-building-claude-code-how-we-use-skills)). Production practice: nine skill categories, Gotchas as highest-signal content, descriptions as trigger specs.
+
+## B. Meta-skills & self-evolving skill methods
+
+5. [skill-mas.md](skill-mas.md) — *Skill-MAS* ([2606.18837](https://arxiv.org/abs/2606.18837), [code](https://github.com/linhh29/Skill_MAS)). Orchestration as an evolvable **Meta-Skill**; multi-trajectory rollout + selective reflection; held-out gate.
+6. [skillevolver.md](skillevolver.md) — *SkillEvolver* ([2605.10500](https://arxiv.org/abs/2605.10500)). Meta-skill that refines **after deployment** from others' failures; fresh-agent overfit + silent-bypass audit.
+7. [muse-autoskill.md](muse-autoskill.md) — *MUSE-Autoskill* ([2605.27366](https://arxiv.org/abs/2605.27366)). Full skill lifecycle (create/memory/manage/evaluate) with unit-tested, experience-aware skills.
+8. [skilladaptor.md](skilladaptor.md) — *SkillAdaptor* ([2606.01311](https://arxiv.org/abs/2606.01311), [code](https://github.com/zjunlp/SkillAdaptor)). **Step-level** failure attribution + acceptance-gated, weight-free updates.
+9. [socratic-swe.md](socratic-swe.md) — *Socratic-SWE* ([2606.07412](https://arxiv.org/abs/2606.07412)). Trace-derived skills steer a self-evolving SWE **curriculum**; 50.4% on SWE-bench Verified.
+10. [embodiskill.md](embodiskill.md) — *EmbodiSkill* ([2605.10332](https://arxiv.org/abs/2605.10332)). Disambiguates **flawed skill vs. execution lapse** before revising; embodied setting.
+
+## C. Skill retrieval & selection at scale
+
+11. [skilldag.md](skilldag.md) — *SkillDAG* ([2606.03056](https://arxiv.org/abs/2606.03056), [code](https://github.com/Ericbai06/SkillDAG)). Typed, conflict-aware skill graph queried and evolved at inference time; holds up as the pool scales 10×.
+12. [sgdr-web-agents.md](sgdr-web-agents.md) — *SGDR* ([2606.04391](https://arxiv.org/abs/2606.04391), [code](https://github.com/plusnli/skill-dynamic-retrieval)). Stepwise, **state-grounded** retrieval for web agents; skills bound to runtime page state.
+
+## D. Harness for continual evolution
+
+13. [skillhone.md](skillhone.md) — *SkillHone* ([2606.08671](https://arxiv.org/abs/2606.08671)). Harness that persists **decision history** (incl. rejected options); role-separated subagents, redacted feedback; +15.8 GAIA.
+
+---
+
+**Threads that recur across the collection** (the design questions autoharness must answer):
+- **Net-effect gating, not failure-count.** Held-out validation (Skill-MAS), acceptance checks (SkillAdaptor), unit tests (MUSE) — accept an edit only if it strictly helps.
+- **Attribution before editing.** Step-level fault localization (SkillAdaptor), skill-vs-lapse disambiguation (EmbodiSkill), silent-bypass detection (SkillEvolver) — don't rewrite a rule that failed because it was ignored.
+- **Persist process, not just the artifact.** Decision history + rejected alternatives (SkillHone) — the audit trail that makes rollback meaningful.
+- **Conflict-aware structure at scale.** Typed conflict edges (SkillDAG) once rules multiply.
+- **Weight-free & portable.** Every method here learns the *document*, not the weights — transferable across models and harnesses.

--- a/docs/research_results/papers/muse-autoskill.md
+++ b/docs/research_results/papers/muse-autoskill.md
@@ -1,0 +1,17 @@
+# MUSE-Autoskill — skill lifecycle management
+
+**Lin, Li, Song, Jiang, Zhang** — "MUSE-Autoskill: Self-Evolving Agents via Skill Creation, Memory, Management, and Evaluation" ([arXiv:2605.27366](https://arxiv.org/abs/2605.27366), 2026-05, 30pp).
+
+> Already noted in the cluster file ([../skill-learning-papers.md](../skill-learning-papers.md)); this is the per-paper read.
+
+Problem: skill-creation methods treat skills as "isolated and static artifacts," limiting reuse, reliability, and long-term improvement. MUSE (Memory-Utilizing Skill Evolution) manages a unified skill lifecycle:
+- **Creation** — generate skills on demand.
+- **Memory** — per-skill memory accumulates experience across tasks.
+- **Management** — organize and select skills efficiently.
+- **Evaluation/Refinement** — validate via **unit tests and runtime feedback**.
+
+Central reframing: skills as long-lived, experience-aware, **testable** assets.
+
+Results: SkillsBench — preliminary evidence of gains in task success, efficiency, skill reuse, and cross-agent transfer (authors mark it work-in-progress).
+
+**Relevance to autoharness:** the *unit-test-the-skill* idea is the validation mechanism a harness optimizer needs; the per-skill memory is the substrate trajectory-bootstrapping reads from.

--- a/docs/research_results/papers/sgdr-web-agents.md
+++ b/docs/research_results/papers/sgdr-web-agents.md
@@ -1,0 +1,12 @@
+# SGDR — online skill learning for web agents via state-grounded retrieval
+
+**Li, Deng, Wang, Huang, Shi, Tan, Lu, Liu** — "Online Skill Learning for Web Agents via State-Grounded Dynamic Retrieval" ([arXiv:2606.04391](https://arxiv.org/abs/2606.04391), 2026-06, 17pp). Code: [plusnli/skill-dynamic-retrieval](https://github.com/plusnli/skill-dynamic-retrieval).
+
+Problem: existing online skill learning retrieves a fixed skill set from the **initial instruction** and holds it constant — misaligned with web execution, where "the appropriate next action depends not only on the task goal but also on the current webpage state." SGDR (State-Grounded Dynamic Retrieval) enables **stepwise** reuse:
+- Sliding-window extraction turns completed trajectories into reusable sub-procedures usable at intermediate states.
+- Dual **text-code** representation links retrieval to executable actions.
+- State-grounded retrieval matches skills to *both* goal and current page state.
+
+Results: WebArena (5 domains) — 37.5% with GPT-4.1, 24.3% with Qwen3-4B; +10.6% / +10.0% relative over the strongest baseline.
+
+**Relevance to autoharness:** retrieval keyed to **runtime state**, not just the task — a reminder that harness behavior is state-dependent, and that skills/rules should bind to the situation they apply in. Sub-trajectory extraction is a granularity option for trajectory-bootstrapping.

--- a/docs/research_results/papers/skill-mas.md
+++ b/docs/research_results/papers/skill-mas.md
@@ -1,0 +1,13 @@
+# Skill-MAS — evolving a meta-skill for multi-agent systems
+
+**Lin (HKUST-GZ), Yang (Ant Group), Qin (HKUST-GZ, corr.)** — "Skill-MAS: Evolving Meta-Skill for Automatic Multi-Agent Systems" ([arXiv:2606.18837](https://arxiv.org/abs/2606.18837), 2026-06). Code: [linhh29/Skill_MAS](https://github.com/linhh29/Skill_MAS).
+
+Problem: automatic multi-agent systems trade off capability vs. experience retention — inference-time methods use strong frozen LLMs but can't learn from past runs; training-time methods learn but are capped at small models. Skill-MAS is a third path: **decouple experience retention from parametric updates** by treating orchestration capability as an evolvable **Meta-Skill** (NL documentation spanning task decomposition, agent engineering, workflow orchestration).
+
+Optimization loop:
+- **Multi-Trajectory Rollout** — K independent trajectories per task turn single outcomes into distributional statistics (uncertainty + difficulty), separating capability from execution noise.
+- **Selective Reflection** — prioritize volatile/hard tasks (joint score + elbow truncation), then hierarchical contrastive analysis (within-task → cross-task) to distill strategy-level principles. Best validation-scoring skill picked for test.
+
+Results: 4 benchmarks (DeepResearchBench, HLE-Math, BrowseComp-Plus, VitaBench) × 4 LLMs; beats inference-time and training-time baselines by a large margin (one exception) at a better cost-performance point. Evolved Meta-Skills transfer across unseen tasks and across LLMs.
+
+**Relevance to autoharness:** lifts the skill-as-trainable-state paradigm from the sub-agent to the **meta-agent orchestration** level, with a held-out validation gate — same selection discipline as [SkillOpt](../skill-learning-papers.md). The orchestration layer is itself harness-shaped.

--- a/docs/research_results/papers/skilladaptor.md
+++ b/docs/research_results/papers/skilladaptor.md
@@ -1,0 +1,9 @@
+# SkillAdaptor — step-level skill adaptation from trajectories
+
+**Yu, Xie, Yao, Wang, Liang, Qi, Deng** — "SkillAdaptor: Self-Adapting Skills for LLM Agents from Trajectories" ([arXiv:2606.01311](https://arxiv.org/abs/2606.01311), 2026-05). Code (planned): [zjunlp/SkillAdaptor](https://github.com/zjunlp/SkillAdaptor).
+
+Problem: training-free skill adaptation that updates from **full trajectories or session-level feedback** localizes failure imprecisely and yields "unstable or overly broad revisions." SkillAdaptor is **step-level** with explicit failure attribution, plugging into "OpenClaw-class agent harnesses." For a failed trajectory it: identifies the first actionable fault step → links responsibility to candidate skills → applies targeted updates under explicit **acceptance checks** → keeps the backbone frozen.
+
+Results: WebShop, PinchBench, Claw-Eval with Kimi-K2.5 / GLM-5 / GPT-5.2 — beats no-skill and skill-adaptation baselines on all three (e.g. +1.8 Claw-Eval, +1.7 WebShop success, +1.5 PinchBench). Argues step-level attribution gives **more stable and auditable** weight-free maintenance.
+
+**Relevance to autoharness:** the failure-attribution granularity question — *which* step/skill/harness layer caused the failure — mirrors [HarnessFix](../paper-list.md). Step-level + acceptance-gated is the precise-edit discipline autoharness needs to avoid broad, regressive rewrites.

--- a/docs/research_results/papers/skilldag.md
+++ b/docs/research_results/papers/skilldag.md
@@ -1,0 +1,9 @@
+# SkillDAG — self-evolving typed skill graphs for selection at scale
+
+**Bai, Wan, Zhou, Yu, Zhao, You, Tsang** — "SkillDAG: Self-Evolving Typed Skill Graphs for LLM Skill Selection at Scale" ([arXiv:2606.03056](https://arxiv.org/abs/2606.03056), 2026-06, 19pp). Code: [Ericbai06/SkillDAG](https://github.com/Ericbai06/SkillDAG).
+
+Problem: with large skill libraries, picking the right subset is a **structural** problem, not similarity matching — skills "depend on, conflict with, specialize, or duplicate one another," structure hidden from both full enumeration and embedding similarity. SkillDAG encodes inter-skill relations as a **typed directed graph** the agent queries at inference time as a structural retrieval interface; it is "queried and evolved during execution," not fixed in a pipeline. Each search returns vector matches + typed-edge neighbors + **conflict signals**; a **propose-then-commit protocol** lets the agent add execution-backed edges, so structure accumulates across episodes.
+
+Results: ALFWorld + SkillsBench with MiniMax-M2.7 — 67.1% success / 27.3% reward, +12.8 / +8.6 over the strongest Graph-of-Skills baseline; transfers to gpt-5.2-codex; intrinsic Ret@K 65.5 → 78.2. Gains hold as the pool scales 10× (fixed pipelines degrade) via "set-monotone online edits."
+
+**Relevance to autoharness:** the **conflict-aware, self-evolving** structure is what a maturing harness needs once skills/rules multiply — explicit conflict edges are a guardrail against contradictory harness rules. Selection-layer peer to the editing-layer optimizers.

--- a/docs/research_results/papers/skillevolver.md
+++ b/docs/research_results/papers/skillevolver.md
@@ -1,0 +1,15 @@
+# SkillEvolver — skill learning as a meta-skill, from failures
+
+**Zhang, Zhu, Zhou, Jia, Wang** — "SkillEvolver: A Meta-Skill for Online Skill Learning from Failures in Agent Self-Evolution" ([arXiv:2605.10500](https://arxiv.org/abs/2605.10500), 2026-05).
+
+Problem: agent skills are static artifacts — "authored once… consumed unchanged, with no mechanism to improve from real use." SkillEvolver is a lightweight, plug-and-play **meta-skill** that repeatedly authors, deploys, and refines domain skills.
+
+Distinguishing choices:
+- Learning target is the skill's **prose and code, not weights** — output works in any agent, no retraining.
+- The meta-skill is itself just a skill, loadable by any protocol-compliant CLI-agent.
+- Unlike trace-distillation, refinement happens **only after deployment**, learning from failures a *different* agent hits while using the skill.
+- A **fresh-agent overfit audit** detects leakage and deployment-specific failures, including a **silent-bypass mode** (skill looks valid but is never actually invoked).
+
+Results: 83 SkillsBench tasks across 15+ domains — 56.8% vs. 43.6% (curated human skills) vs. 29.9% (no-skill). KernelBench GPU-kernel: mean speedup 1.16 → 1.51.
+
+**Relevance to autoharness:** closest sibling to the harness wedge — post-deployment, failure-driven, weight-free, with an explicit **overfit/silent-bypass audit**. The silent-bypass check is a guardrail autoharness should adopt: an edit that is never exercised is not an improvement.

--- a/docs/research_results/papers/skillhone.md
+++ b/docs/research_results/papers/skillhone.md
@@ -1,0 +1,13 @@
+# SkillHone — a harness for continual evolution via decision history
+
+**Li, Hu** — "SkillHone: A Harness for Continual Agent Skill Evolution Through Persistent Decision History" ([arXiv:2606.08671](https://arxiv.org/abs/2606.08671), 2026-06).
+
+Problem: existing approaches improve skills only within bounded runs and "retain only the final artifact, discarding the decision history" — so future agents can't see earlier revisions, evaluations, or rejected options. SkillHone is a **harness** anchored in persistent decision history:
+- Couples skill revisions with evaluation-side evidence that supplies practice feedback.
+- Records structured logs of diagnoses, revisions, evidence, and outcomes.
+- **Role-separated subagents** test candidates on practice probes with **redacted reporting** and propose revisions informed by past decisions.
+- Enables cross-session refinement without rediscovering past rationale.
+
+Results: deep-research benchmarks in a raw open-web setting (no integrated search stack), Qwen3.6-35B-A3B backbone — **+15.8 on GAIA**, +3.2 on WebWalkerQA-EN; also beats prior skill-evolution methods.
+
+**Relevance to autoharness:** the most direct harness-engineering peer in this collection — treats the **harness itself as the locus of improvement** and persists *process* (including rejected alternatives), not just the final skill. Role separation + redacted feedback are concrete guardrail patterns; persisting rejected options is exactly the audit trail autoharness's rollback story needs.

--- a/docs/research_results/papers/skillwiki.md
+++ b/docs/research_results/papers/skillwiki.md
@@ -1,0 +1,11 @@
+# SkillWiki — living knowledge infrastructure for skills
+
+**Huang, Ding, Liu, … Yu, Sui (11 authors)** — "SkillWiki: A Living Knowledge Infrastructure for Agent Skills" ([arXiv:2606.16523](https://arxiv.org/abs/2606.16523), 2026-06). Demo + code: [Huangdingcheng/SkillWiki](https://github.com/Huangdingcheng/SkillWiki).
+
+Premise: Wikipedia manages knowledge, GitHub manages software, but agent skills "still lack an infrastructure for large-scale production, governance, and evolution."
+
+Mechanism: convert heterogeneous knowledge into reusable skill assets while preserving links back to originating evidence (**provenance-aware grounding**). Covers the full lifecycle — knowledge ingestion → skill production → provenance-aware exploration → governance → execution-driven evolution. Delivered as a demonstration system, not a benchmark study.
+
+Vision: knowledge, skills, and execution experience co-evolve in one shared infrastructure.
+
+**Relevance to autoharness:** the *governance + provenance* angle — every skill/harness edit traceable to its evidence — aligns with autoharness's audit/gate/rollback wedge. Infrastructure peer rather than an optimizer.

--- a/docs/research_results/papers/socratic-swe.md
+++ b/docs/research_results/papers/socratic-swe.md
@@ -1,0 +1,11 @@
+# Socratic-SWE — self-evolving coding agents via trace-derived skills
+
+**Xiao, Jiao, Wang, Wang, Zhao, Wei, Zhang, Qu** — "Socratic-SWE: Self-Evolving Coding Agents via Trace-Derived Agent Skills" ([arXiv:2606.07412](https://arxiv.org/abs/2606.07412), 2026-06).
+
+Problem: training SWE agents is bottlenecked by scarce high-quality tasks; fixed mutation / bug-injection synthesis produces task distributions disconnected from the agent's actual weaknesses. Socratic-SWE is a closed loop that recycles the agent's own solving **traces** as training signal — distilling them into structured agent skills that capture recurring failures and repair patterns, then using those skills to **generate targeted repair tasks in real repos**.
+
+Loop: candidate tasks pass execution-based validation → scored by a **solver-gradient alignment reward** (keep tasks both verifiable and useful) → updated solver generates new traces → curriculum adapts each round.
+
+Results: SWE-bench Verified/Lite/Pro, Terminal-Bench 2.0 — consistently beats self-evolving baselines at equal compute; **50.40% on SWE-bench Verified after three iterations**.
+
+**Relevance to autoharness:** demonstrates traces as "a scalable substrate for self-evolving agents" — the same trajectory-bootstrapping premise, applied to curriculum rather than harness. The solver-gradient-alignment filter (keep only *useful* derived artifacts) is a selection idea worth porting.


### PR DESCRIPTION
## What

A new per-paper **paper collection** under `docs/research_results/papers/` — the Apr–Jun 2026 wave on externalized **skills, meta-skills, and self-evolving harnesses**. Each of the 13 shared sources gets a standalone summary (core problem · method · results · relevance to autoharness); the collection `index.md` groups them by theme and records every arXiv + code link.

This is a *deeper, per-paper* read that complements the prior compressed landscape in `research_results/` — overlaps (e.g. MUSE-Autoskill) are cross-linked, not duplicated.

## Contents (13 sources, grouped)

- **A. Framing, surveys & infrastructure** — Externalization review (the umbrella: memory/skills/protocols/**harness**), Agent Skill Eval&Evolution survey, SkillWiki, Claude Code skills blog.
- **B. Meta-skills & self-evolving methods** — Skill-MAS, SkillEvolver, MUSE-Autoskill, SkillAdaptor, Socratic-SWE, EmbodiSkill.
- **C. Skill retrieval & selection at scale** — SkillDAG, SGDR (web agents).
- **D. Harness for continual evolution** — SkillHone.

## Recurring threads (the design questions for autoharness)

Net-effect gating (not failure-count) · attribution before editing · persist *process* incl. rejected options · conflict-aware structure at scale · weight-free & portable skill documents.

## Wiring

- New: `docs/research_results/papers/` (13 summaries + index).
- Updated: `docs/research_results/index.md` and `docs/index.md` to point at the collection.

Docs/research-notes only — no code, tests, or schema touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)