### PR TITLE
docs(research-loom): experience lifecycle management (Hermes curator skeleton) + provenance membership + trigger timing

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -27,6 +27,10 @@
   quartetfuzz). Decide where the ecosystem-heat / output-quality-validation content moved (likely a new
   synthesis note) and relink. `sources/papers/index.md` already repointed to `synthesis/index.md` as a
   stopgap.
+- [ ] **生命周期/去重的触发时机:适配非常驻宿主.** Hermes 的 curator 靠常驻 daemon(空闲 2h / 间隔 7d 自动醒);
+  Claude Code 等是临时进程,会话间无常驻、不会空闲自动醒,墙钟周期 sweep 无执行者。需定:失活走惰性判定
+  (SessionStart/注入时按时间戳现算)、去重走准入事件驱动;并决定失活刻度用墙钟天还是使用相对(几次会话未被用)。
+  见 [`research-loom/ideas/adherence-driven-curate.md`](research-loom/ideas/adherence-driven-curate.md) 的待解。
 - [ ] **Wire doc checkers into CI.** `tools/check_doc_links.py` + `tools/check_research_loom.py`
   (and their `--selftest`) should gate PRs once a `.github/workflows` exists. Blocked on the
   `DEFINITION.md` danglers above (link checker is non-zero until they're fixed).

--- a/docs/research-loom/ideas/adherence-driven-curate.md
+++ b/docs/research-loom/ideas/adherence-driven-curate.md
@@ -3,25 +3,33 @@ id: adherence-driven-curate
 type: idea
 status: 候选
 ---
-# 滚动 curate：用「被遵守 / 被矛盾」的统计动态给符号定生死
+# 经验生命周期管理:Hermes curator 式状态机为骨架,保留 ECC 的遵守度理念
 
-> 借鉴 [ECC](../sources/github/affaan-m-ecc.md) 设计（它没实现），user 认可此方向，status 候选，待复核。
+> 以 [Hermes](../sources/github/nousresearch-hermes-agent.md) curator 的**已落地**机制为主,叠加 [ECC](../sources/github/affaan-m-ecc.md)「按遵守度定生死」的**理念**(它没实现、也不一定好实现)。user 认可,status 候选,待复核。
 
-**主张**：符号的进化不是一次性打分，而是**永不终止的滚动 curate**——每个符号的权重随它在真实运行中**被遵守还是被违背**持续浮动：
+**主张**:符号沉淀后不是一次性打分,而是进入一条**永不终止的生命周期**——会上浮、下沉、退役。怎么实现分两层,**骨架先用能跑的,理念留作升级轴**:
 
-- 被矛盾 / 被无视 → 权重衰减；
-- 复现 / 被遵守 → 权重上升；
-- 跨项目复现 → scope 由 project 升 global；
-- 跌破阈值 → **事实性死亡**（不再注入，等于退役）。
+**① 骨架(主,照 Hermes curator——已验证可落地)。** 必须把**机制**和**触发时机**拆开:机制可借,时机不可照搬。
+- **机制(借 Hermes):** 确定性失活状态机 `active → stale(久未用) → archived(更久未用)`,再被用到就 reactivate;**只归档、不删除**(可恢复),退役可逆;成员资格按 [provenance 划线](lifecycle-by-provenance.md);重组(合并近义/umbrella)作为**可选**的、更贵的一档,默认不开。
+- **触发时机(不照搬 Hermes 的 daemon):** Hermes 靠"空闲 2h、间隔 7d 自动醒"的**常驻 daemon**——但 Claude Code 等是**临时进程**,会话间无常驻、不会"空闲自动醒",墙钟周期 sweep **没有执行者**。改为:**失活走惰性判定**(墙钟天数只当判定谓词,在 `SessionStart`/注入符号那一刻用时间戳**现算** stale/退役,不靠 daemon fire),**去重走准入事件驱动**(新符号入场才比,本就不需 daemon)。
 
-关键约束:这里的「矛盾」是**符号 vs 实际行为**(说一套做一套),**不是符号之间的矛盾**。后者(结构化冲突/重复/包含)属另一条轴,归 [结构化把关](structural-gate-no-oracle.md);本卡只管「用得好不好」的使用信号轴。两轴正交:结构门管**能不能进**,滚动 curate 管**进来后活多久**。
+**② 理念(保留,照 ECC——方向认可但难实现):** 把"定生死"的依据从**纯时间(多久没用)**升级为**遵守度(被遵守 / 被矛盾)**。
+- 被矛盾 / 被无视 → 下沉;复现 / 被遵守 → 上浮;跨项目复现 → scope 升 global;跌破阈值 → 事实性退役。
+- **诚实**:这要可靠地测"符号 vs 实际行为是否一致",ECC 设计了却从未实现,**autoharness 也不一定好做**;所以它是骨架之上的**升级方向**,不是第一版前提。先有 Hermes 式时间/使用状态机能跑,再朝遵守度加权演进。
+
+关键约束:这里的「矛盾」是**符号 vs 实际行为**(说一套做一套),**不是符号之间的矛盾**。后者(结构化冲突/重复/包含)属另一条轴,归 [结构化把关](structural-gate-no-oracle.md);本卡只管「用得好不好」的存活轴。两轴正交:结构门管**能不能进**,生命周期管**进来后活多久**。
 
 ## 论据 / 出处
 
-[ECC](../sources/github/affaan-m-ecc.md) 的 `agents/observer.md` 写明了这套标量动态(`+0.05`/确认、`-0.1`/矛盾、`-0.02`/周衰减、2+ 项目且 avg≥0.8 升 global),但代码级审计证实**全是死规格**:无任何代码回读改写 confidence,confidence 写死一次,活跃符号永不过期。所以这是 ECC「设计了没做」的一块——思路成立,实现是 autoharness 的空白(也正是 [ECC 卡](../sources/github/affaan-m-ecc.md) 列出的第 4 条 wedge:真正不回退的滚动 curate)。
+**骨架来自 [Hermes](../sources/github/nousresearch-hermes-agent.md) curator(本会话读源码核实):** 确定性失活状态机 `active→stale(30d)→archived(90d)`、**never delete only archive**、pin 豁免、按记录/渠道圈定管理范围、LLM 合并(umbrella)`DEFAULT_CONSOLIDATE=False` 默认关。这是目前唯一**实际在跑**的经验生命周期实现——可直接当骨架借。
 
-ECC 用标量打分当它**唯一的**「冲突」处理——没有结构化冲突扫描。我们认可标量动态作为**使用信号轴**,但不让它替代结构轴:autoharness 两者都要。
+**理念来自 [ECC](../sources/github/affaan-m-ecc.md)(设计了没做):** `agents/observer.md` 写明标量动态(`+0.05`/确认、`-0.1`/矛盾、`-0.02`/周衰减、2+ 项目 avg≥0.8 升 global),但代码审计证实**全是死规格**——无代码回读改写 confidence,活跃符号永不过期。所以"按遵守度定生死"是**认可的方向、未证可行的实现**(也正是 [ECC 卡](../sources/github/affaan-m-ecc.md) 第 4 条 wedge)。两边互补:**Hermes 给可跑的退役骨架,ECC 给更优的决策信号——前者先落地,后者作演进。**
+
+## 待解 / 边界
+
+- **失活刻度:墙钟天 vs 使用相对。** 非 24h 激活时,"30 天没碰"语义可疑——日历 30 天里只开过两次会话,跟高频使用下 30 天没碰,完全不同。也许刻度该是**使用相对的**(几次会话 / 几次注入未被用)而非日历天;这又正好接回 ② 的遵守度/使用信号轴。
+- **会话边界触发的覆盖盲区。** 惰性 + `SessionStart` 触发意味着**长期不开会话就不跑**;是否需要兜底(下次开会话时一次性补算积压),以及补算会不会一次退役过多,待定。
 
 ## 关联
 
-与 [结构化把关](structural-gate-no-oracle.md) 正交互补(准入 vs 存活)。所需的「被遵守/被矛盾」信号,来自 [历史 trace 提模式](trace-based-pattern-extraction.md) 同一条抓取流。「事实性死亡 = 不再注入」依赖 [hook 强制注入](hook-forced-injection.md) 的注入闸作为退役开关。
+成员资格规则见 [按 provenance 划生命周期](lifecycle-by-provenance.md)。与 [结构化把关](structural-gate-no-oracle.md) 正交互补(准入 vs 存活)。「遵守度」信号若要实现,需 [直接读用户输入与 agent 输出](read-prompt-not-just-trace.md) / [历史 trace 提模式](trace-based-pattern-extraction.md) 供料。「退役 = 不再注入」依赖 [hook 强制注入](hook-forced-injection.md) 的注入闸。装配进 [design/](../design/index.md) 的 Manage 段。

--- a/docs/research-loom/ideas/index.md
+++ b/docs/research-loom/ideas/index.md
@@ -7,7 +7,8 @@
 - [维护层只能叠加，不得改写原生 skill 体验](additive-over-native-skill.md) — `候选`（user 提出的产品边界，待复核）
 - [从历史 trace 里提模式：候选符号的无标注来源](trace-based-pattern-extraction.md) — `候选`（借鉴 ECC 抓取前端，待复核）
 - [按轮次在 episode 边界自动反思、整段蒸馏 skill——优于 ECC 逐调用从 hook 抓碎片](episode-boundary-reflection.md) — `候选`（user 认可：Hermes 整段 replay 反思优于 ECC hook 抓流，待复核）
-- [滚动 curate：用被遵守/被矛盾的统计动态给符号定生死](adherence-driven-curate.md) — `候选`（借鉴 ECC 未实现的设计，user 认可，待复核）
+- [经验生命周期管理：Hermes curator 状态机为骨架，保留 ECC 遵守度理念](adherence-driven-curate.md) — `候选`（以 Hermes 已落地机制为主 + ECC 遵守度理念为升级轴，待复核）
+- [默认只有机器自学经验进生命周期；其他来源可 opt-in 自动沉降](lifecycle-by-provenance.md) — `候选`（user 提出：按 provenance 划生命周期成员，待复核）
 - [skill 召回率本就不高，且随 skill 数量增长而恶化](skill-recall-low-degrades-with-n.md) — `候选`（user 提出：读取率不高、越多越差，待复核）
 - [直接读用户输入与 agent 输出，而非从 tool 执行反推](read-prompt-not-just-trace.md) — `候选`（user 对 ECC 抓取口的修正，待复核）
 - [经验沉淀后存哪一层：独立 instinct 层 vs 新增 skill](precipitate-storage-layer.md) — `存疑`（开放问题，待证据收窄后开决策）

--- a/docs/research-loom/ideas/lifecycle-by-provenance.md
+++ b/docs/research-loom/ideas/lifecycle-by-provenance.md
@@ -1,0 +1,28 @@
+---
+id: lifecycle-by-provenance
+type: idea
+status: 候选
+---
+# 默认只有机器自学经验进生命周期;其他来源可 opt-in 自动沉降
+
+**主张**:生命周期(进 [滚动 curate](adherence-driven-curate.md):衰减 / 失活 / 淘汰 / 自动沉降)的**成员资格按 provenance 默认划线**——
+
+- **默认入池 = 机器自学的经验**(本系统自产的符号)。它本就是"基于使用信号自增长、自维护"的东西,理应有完整生命周期:用得好上浮、被矛盾下沉、长期没用自动沉降退役。
+- **默认在池外 = 其他来源**(用户手写、外部下载、Hub 装、原生 skill)。不被自动沉降——这守住 [维护层只能叠加、不得改写原生](additive-over-native-skill.md):系统不擅自给人意符号判生死。
+- **但用户可显式 opt-in**:把指定的其他来源符号也纳入生命周期,让它们一样享受**自动沉降**(自动 stale/降权/归档)。这是一个**正向加入**动作,不是默认就卷进去。
+
+划线的轴必须是**系统内生的所有权标记(机器自产 vs 外来)**,而非外部清单或文件位置——见下文对照。
+
+## 论据 / 出处
+
+[Hermes](../sources/github/nousresearch-hermes-agent.md) 的代码实证给了正反两面:它**也**只对 `skill_manage create` 的自产物跑失活(30/90 天),其余默认豁免——方向对。但它的保护轴是**外部渠道清单(bundled/hub)+ 手动逐个 `pin`**,且"认不认管理"还要靠 `.usage.json` 记录、明说「manually authored skills are not inferred from filesystem location」。两个教训:(1) 默认按 provenance 分池是对的;(2) 但**所有权不能只靠外部清单/人手 pin**——那对"用户即兴 `/learn`、手动 clone"有识别盲区。autoharness 据此把成员资格做成**系统内生标记 + 显式 opt-in 加入**,而不是 Hermes 那种"默认豁免、手动 pin 退出"。
+
+## 待解 / 边界
+
+- opt-in 的**粒度与可逆性**:逐符号 / 按目录 / 按来源类别?纳入后能否退出(对称 opt-out)?
+- 纳入后的人意符号,自动沉降到底是"归档可恢复"还是"降权不删"——退役动作的强度需与 provenance 挂钩(外来的更保守)。
+- 与 [经验沉淀存哪一层](precipitate-storage-layer.md) 耦合:若机器经验独立成层,opt-in 是"把外来 skill 复制进经验层"还是"给原层打生命周期标记"?待那条决策收窄。
+
+## 关联
+
+是 [滚动 curate](adherence-driven-curate.md) 的**成员资格规则**(谁进这条流);受 [维护层只能叠加、不得改写原生](additive-over-native-skill.md) 约束(默认不碰外来);所有权标记的内生化呼应同一张卡的教训。装配进 [design/](../design/index.md) 的 Manage 段。


### PR DESCRIPTION
## What changed this time

Continuing this round's code-level audit of the Hermes-Agent curator, the experience-maintenance idea is re-arranged from "centered on ECC's unimplemented design" into a **landable skeleton + upgrade axis**, with two new conclusions added.

### 1. `adherence-driven-curate` retitled "experience lifecycle management"
- **Skeleton (primary, modeled on the Hermes curator — verified landable)**: deactivation state machine `active→stale→archived`, archive-only (never delete), pin exemption, scoping by provenance, umbrella merging off by default.
- **Philosophy (retained, modeled on ECC — endorsed but hard to implement)**: upgrade the life-or-death criterion from pure time to **adherence (followed / contradicted)**; honestly noting that ECC designed but did not build it, and autoharness may not find it easy either — treated as an upgrade axis, not a v1 premise.
- **Separate "mechanism" vs "trigger timing"**: Hermes's resident daemon (wakes automatically after 2h idle / every 7d) is **not copied wholesale** — ephemeral hosts like Claude Code have no resident process between sessions and never wake on idle, so a wall-clock sweep has no executor; replaced with **lazy** deactivation evaluation (computed on the spot from timestamps at SessionStart/injection) + **event-driven** dedup admission.

### 2. New idea `lifecycle-by-provenance`
By default only machine-self-learned experience enters the lifecycle; other sources (handwritten / downloaded / Hub / native) are outside the pool by default and can **opt-in** to automatic settling. Per the lesson from Hermes's code: provenance cannot rely only on external manifests (bundled/hub) + manual pin (which has blind spots for ad-hoc /learn and manual clone) — it requires a **system-intrinsic ownership marker**.

### 3. Open questions / TODO
- In-card `open`: deactivation scale in wall-clock days vs usage-relative; coverage blind spots from session-boundary triggers.
- `docs/TODO.md`: lifecycle/dedup trigger timing — adapting to non-resident hosts.

## Scope
Pure research-loom docs (ideas layer + TODO). `tools/check_research_loom.py` frontmatter check passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)