### PR TITLE
docs(research-loom): scenario-evidence recording (record-only) + maintenance decoupled from self-accumulation + precipitate-layer direction B

### DIFF
--- a/docs/research-loom/ideas/index.md
+++ b/docs/research-loom/ideas/index.md
@@ -11,4 +11,6 @@
 - [默认只有机器自学经验进生命周期；其他来源可 opt-in 自动沉降](lifecycle-by-provenance.md) — `候选`（user 提出：按 provenance 划生命周期成员，待复核）
 - [skill 召回率本就不高，且随 skill 数量增长而恶化](skill-recall-low-degrades-with-n.md) — `候选`（user 提出：读取率不高、越多越差，待复核）
 - [直接读用户输入与 agent 输出，而非从 tool 执行反推](read-prompt-not-just-trace.md) — `候选`（user 对 ECC 抓取口的修正，待复核）
-- [经验沉淀后存哪一层：独立 instinct 层 vs 新增 skill](precipitate-storage-layer.md) — `存疑`（开放问题，待证据收窄后开决策）
+- [创建/更新/使用场景随符号留痕——为高频符号自举 per-symbol eval 预存素材](record-scenarios-for-eval.md) — `候选`（user 提出：造/改 skill 时记下凭据，参考 SkillHone；暂只记录不验证，待复核）
+- [维护可脱离自积累单独成立——只维护已有 skill 不自动生成](maintenance-without-self-accumulation.md) — `候选`（user 提出：服务只想自动维护、不想自积累的用户，待复核）
+- [经验沉淀后存哪一层：倾向 B 新增为 skill（参考 Hermes）、独立 instinct 层作苗圃](precipitate-storage-layer.md) — `候选`（user 取向 B：skill 可传播；正式 ADR 待开）

--- a/docs/research-loom/ideas/maintenance-without-self-accumulation.md
+++ b/docs/research-loom/ideas/maintenance-without-self-accumulation.md
@@ -1,0 +1,26 @@
+---
+id: maintenance-without-self-accumulation
+type: idea
+status: 候选
+---
+# 维护可脱离自积累单独成立——为「不想自动生成新 skill、但想自动维护已有 skill」的用户提供方案
+
+> user 提出：这套生命周期也能服务只想维护、不想自积累的用户。status 候选，待复核。
+
+**主张**：经验生命周期 / curate 机制对符号的**来源不可知**——它管机器自学出的符号，同样管用户手写的原生 skill。于是「**自积累**（自动生成新符号）」与「**维护**（对已有符号去重 / 退役 / 纠偏 / 上浮）」是**可解耦的两件事**，能分别交付。存在一类用户：不信任或不想要自动生成，却确实苦于手写 skill 越攒越多、互相打架、过期失效——给他们「**只维护、不生成**」的模式，是更低门槛的入口，也扩大可服务人群。
+
+## 论据 / 出处
+
+- [滚动 curate](adherence-driven-curate.md) 借的 [Hermes](../sources/github/nousresearch-hermes-agent.md) curator 骨架（失活状态机、never-delete-only-archive、按 provenance 圈管理范围）作用于「一个符号集合」，**不要求集合里的符号是机器生成的**——这正是「只维护」模式可独立成立的机制依据。
+- 是 [按 provenance 划生命周期](lifecycle-by-provenance.md) 的**正向用例**：那条卡主张「默认只有机器自学经验进生命周期，其他来源 opt-in」；本卡即用户把**手写 skill opt-in 进维护、却不开自积累**——同一个 provenance 旋钮的两档。
+- [skill 召回随数量恶化](skill-recall-low-degrades-with-n.md) 对手写 skill 同样成立，所以「自动维护已有 skill」有**独立刚需**，不依赖自积累。
+- 定位含义：「只维护」对商业/谨慎用户尤其友好（无新增行为 = 低风险、易合规），是 audit/gate/rollback 治理卖点的**轻量入口**——呼应 general 滩头 vs 商业市场的排序。
+
+## 待解 / 边界
+
+- 与 [维护层只能叠加](additive-over-native-skill.md) 的张力：维护已有 skill 必然要改写/退役原生 skill，与「纯叠加、零侵入」边界直接冲突。只维护模式下「侵入」是**用户显式授权**的，需要一份不同于自积累模式的**授权 / 回滚契约**。
+- 成品边界：「只维护」与「维护 + 自积累」是两个 SKU 还是一个开关，待定。
+
+## 关联
+
+是 [按 provenance 划生命周期](lifecycle-by-provenance.md) 的正向用例；复用 [滚动 curate](adherence-driven-curate.md) 的 curator 骨架；与 [维护层只能叠加](additive-over-native-skill.md) 张力待解。将装配进 [design/](../design/index.md) 的 Manage 段（兼产品定位）。

--- a/docs/research-loom/ideas/precipitate-storage-layer.md
+++ b/docs/research-loom/ideas/precipitate-storage-layer.md
@@ -1,13 +1,20 @@
 ---
 id: precipitate-storage-layer
 type: idea
-status: 存疑
+status: 候选
 ---
-# 待定：经验自动沉淀后存在哪一层——独立 instinct 层，还是新增 skill？
+# 经验自动沉淀后存在哪一层——倾向 B（新增为 skill，参考 Hermes），独立 instinct 层留作苗圃
 
-> 一个尚未落定的开放问题（非主张），status 存疑，待证据收窄后开 [决策工作表](../decisions/index.md) 坍缩。
+> 原为开放问题。user 取向：**选 B，沉淀物长成原生 skill**（参考 [Hermes](../sources/github/nousresearch-hermes-agent.md)），新增驱动力 = **可传播**（skill 是天然可分发单元，独立 instinct 私有层不便传播）。status 升 候选；正式坍缩成 ADR 待开。
 
-**问题**：维护层把 trace 蒸馏出的经验固化为符号后，这些符号的**存储形态**该是什么？两条候选并行养着，先不押一个：
+## 取向（user）
+
+倾向 **B**：沉淀物固化为原生 skill，复用注册/读取链路，且**便于在用户间传播分享**。两条遗留张力转由别处消化，不在本卡内重证：
+
+- 「B 是否仍算纯叠加」（[维护层只能叠加](additive-over-native-skill.md) 的边界）：维护已有 skill 必然要改写/退役，授权与回滚契约由 [维护脱离自积累](maintenance-without-self-accumulation.md) 处理。
+- 「原生 skill 机制能否承载 curate 退役」：保留**混合解**作落地路径——沉淀先入独立 instinct 层做 curate（苗圃），存活到阈值再「毕业」固化为可分发 skill（成品架）。
+
+**问题**（原始陈述，保留）：维护层把 trace 蒸馏出的经验固化为符号后，这些符号的**存储形态**该是什么？两条候选：
 
 - **A — 独立一层（instinct-like）**：另开一类 rule.md / instinct 存储，与原生 skill 平级、彼此隔离；维护层全权管它的增删改与注入，不经过 skill 注册链路。
 - **B — 新增为 skill**：沉淀产物直接长成原生 skill（SKILL.md），复用既有的注册、读取、description 概率触发路径，不另立存储。

--- a/docs/research-loom/ideas/record-scenarios-for-eval.md
+++ b/docs/research-loom/ideas/record-scenarios-for-eval.md
@@ -1,0 +1,27 @@
+---
+id: record-scenarios-for-eval
+type: idea
+status: 候选
+---
+# 创建/更新/使用场景随符号留痕——为高频符号日后自举 per-symbol eval 预存素材（现阶段只记录、不验证）
+
+> user 提出：造 skill 时连同凭据一起记下来，日后可成 eval 集。status 候选，待复核。
+
+**主张**：符号（skill / 经验）在三个时刻都把**场景证据**作为随附数据持续记录——① **创建**时记下触发它的那组重复场景（凭什么造它）；② **每次更新**时记下本次改动的证据与场景（凭什么改）；③ **运行**时记下实际命中的使用场景（被召回时真实长什么样）。这些留痕本身**不裁决、不验证**，只是日后给**高频符号自举 per-symbol eval 集**的料。本卡范围严格限定在**捕获/记录**；replay/打分留到证据足够再开，是一道刻意的延迟。
+
+## 论据 / 出处
+
+- [SkillHone](../sources/papers/skillhone.md) 是直接范式：它把 skill revision 与 evaluation-side evidence 耦合，持久记录 diagnoses / revisions / evidence / outcomes，并论证「只留最终 artifact、丢掉决策史」是硬伤。本卡把这种「更新留痕」从它的专门机制，降为**每次 create/update/use 都顺手攒的常规副产物**——含被否决的备选，正是 autoharness 回滚故事要的审计轨。
+- 下游对接 [离线评测验证](../synthesis/offline-validation.md) 的子类②（自有 trace 自举 eval）：本卡是其**上游备料**——把「日后要当验证集的料」在当场就攒好；并须守住该方向红线「生成某候选的 trace 不得验证它」，故创建/更新所凭场景与日后验证集**必须分账**。
+- 创建所凭的「重复场景」即 [从 trace 提模式](trace-based-pattern-extraction.md) 的 3+ 复现，天然是该符号的**正例种子**；每次留痕发生在 [episode 边界](episode-boundary-reflection.md) 上，场景证据 = 该 episode 的 replay 切片。
+- 与 [结构化把关，不要 held-out 分数](structural-gate-no-oracle.md) / [ADR-0001](../decisions/ADR-0001-structural-gate.md) **不冲突**：本卡不引入裁决，只预存素材，因此不破坏「无 oracle 准入」；反而把「要不要自举 oracle」那道悬置问题，从「现在裁决」降级为「先把料攒着」。
+
+## 待解 / 边界
+
+- **脱敏前置**：使用场景含用户原话，PII/密钥风险高于 tool I/O（见 [直接读 prompt](read-prompt-not-just-trace.md)）——留痕入库前必须过红线过滤（CLAUDE.md 安全条款）。
+- **配额与去重**：高频符号会堆大量使用场景，需采样/配额，免得留痕本身膨胀；每条须标 provenance（哪个 session/episode）以便日后 split。
+- **何时从「只记录」转「开始验证」**：触发阈值（符号频次 / 场景累积量）待定，不在本卡内定。
+
+## 关联
+
+上游承 [从 trace 提模式](trace-based-pattern-extraction.md)、[episode 边界反思](episode-boundary-reflection.md)；下游喂 [离线评测验证](../synthesis/offline-validation.md) 子类②；成员资格随 [按 provenance 划生命周期](lifecycle-by-provenance.md)；使用场景同时供 [滚动 curate](adherence-driven-curate.md) 的「被遵守/被矛盾」判定。与 [结构化把关](structural-gate-no-oracle.md) 正交（只存料、不裁决）。将装配进 [design/](../design/index.md) 的 Intake/Manage 段。


### PR DESCRIPTION
This session's design discussion settles into three blocks under research-loom `ideas/`.

## Three idea blocks

1. **New card `record-scenarios-for-eval`** — at the create/update/run moments, a symbol continuously records **scenario evidence** as accompanying data, to serve as material for later **bootstrapping a per-symbol eval set** for high-frequency symbols; **at this stage record only, do not validate** (deliberately deferred). References [SkillHone](https://arxiv.org/abs/2606.08671)'s persistent decision history (source card already exists). Upstream connects to `trace-based-pattern-extraction` / `episode-boundary-reflection`, downstream feeds `synthesis/offline-validation` subtype ②; **orthogonal** to `structural-gate-no-oracle` (only stores material, makes no rulings, does not break "no-oracle admission").
2. **New card `maintenance-without-self-accumulation`** — "self-accumulation" and "maintenance" can be decoupled: provide a "maintain-only" mode for users who **only want to auto-maintain existing skills, not self-accumulate** (lower barrier, friendly to commercial/cautious users). It is a positive use case of `lifecycle-by-provenance`; the boundary tension with `additive-over-native-skill`'s zero-intrusion remains to be resolved (requires explicit authorization / rollback contract).
3. **`precipitate-storage-layer` promoted to `candidate`** — user leans toward **B (precipitate grows into a native skill, referencing Hermes)**, with a new driver = **propagatability**; the independent instinct layer remains as a **nursery** (hybrid solution: instinct nursery → finished skill shelf). Formal collapse into an ADR pending.

## Checks

- `python3 tools/check_research_loom.py docs/research-loom` → **ok**
- `python3 tools/check_doc_links.py docs` → only **pre-existing** dangling links remain (`DEFINITION.md` / top-level `design/` / `synthesis/ecosystem-heat.md`); **this PR introduces no new dangling links**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)