### PR TITLE
docs(research-loom): core idea "dynamic-validation lifecycle" + reorder the standing of offline replay

### DIFF
--- a/docs/research-loom/ideas/dynamic-validation-lifecycle.md
+++ b/docs/research-loom/ideas/dynamic-validation-lifecycle.md
@@ -1,0 +1,32 @@
+---
+id: dynamic-validation-lifecycle
+type: idea
+status: 候选
+---
+# 核心理念：在动态工作中积累并验证经验，而非定期收集 eval 跑进化
+
+> user 倡导为**核心理念**（thesis 级）。status 候选，待复核。
+
+**主张**：经验的积累**与验证**都应在**真实工作流里就地、随交互发生**（in-the-loop），而不是「定期攒一个 eval 集 → 离线跑一轮进化/裁决」。理由是环境**随每次交互漂移**：基于历史 trace 建的 eval 会过期——昨天验证成立的依据，今天的环境已不复存在，历史依据失效。因此验证必须**随用随验**：一个符号靠「在后续真实交互中持续被遵守、奏效」挣得存活，而非靠一次离线 replay 拿到的快照分；且**历史依据本身随环境衰减、退役**，不是永久 golden。
+
+## 三道闸的重新分工（本理念的落点）
+
+把「接不接受 / 活不活」拆三道，**动态验证升为主裁决**：
+
+- **准入（即时·便宜）**：[结构门](structural-gate-no-oracle.md)——去重 / 冲突 / 边界，放行候选。
+- **存活（持续·主）**：**动态验证**——在真实交互里持续被遵守 / 奏效才活，被矛盾 / 失效则下沉退役。即把 [滚动 curate](adherence-driven-curate.md) 里 ECC 的「遵守度」理念从「升级轴」提为**核心机制**。
+- **兜底（重·偶尔）**：[离线 replay](../synthesis/offline-validation.md) 降为**高风险、或结构 + 动态都拿不准时**才动用，不再是常规裁决轴。
+
+## 论据 / 出处
+
+环境漂移使历史 eval 失效，是 [离线 replay 子类②](../synthesis/offline-validation.md) 在自评偏差（[SkillLens](../sources/papers/skilllens.md) 把上限按在 ≈46.4%）之外的**第二重隐患**——本理念再加一条「靶子本身在移动」。动态验证的可行机制来自 [直接读 prompt / 输出](read-prompt-not-just-trace.md)：遵守度**字面可观测**，使「随用随验」不必重放即可拿信号。定位上，这把 autoharness 与 [SkillOpt](../sources/papers/skillopt.md) / offline-eval 那种「周期收集 eval → 进化」家族**划开**。
+
+## 待解 / 边界
+
+- **重开决策**：本理念把 [离线 replay](../synthesis/offline-validation.md) 从「autoharness 的裁决轴（落子类②）」降为兜底——直接重开那条已采纳方向，须开 [决策工作表](../decisions/index.md)（驱动力：环境漂移下的有效性 / 成本 / 自评偏差 / 安全兜底）。
+- **信号强度**：遵守度是弱信号（「照做了」≠「做对了」），高风险动作仍可能需兜底 replay——主 / 兜底边界按风险分。
+- 与 [record-scenarios-for-eval](record-scenarios-for-eval.md) 的衔接：记录的使用场景不再只是「将来 eval 集的料」，而是**随用随验 + 随环境过期**的滚动证据。
+
+## 关联
+
+重排 [离线评测验证](../synthesis/offline-validation.md) 的地位（裁决轴 → 兜底）；把 [滚动 curate](adherence-driven-curate.md) 的遵守度理念提为核心；与 [结构门](structural-gate-no-oracle.md) 组成三道闸；给 [record-scenarios-for-eval](record-scenarios-for-eval.md) 的记录赋予「滚动过期」语义。是 DEFINITION 级理念，装配进 [design/](../design/index.md) 脊柱与定位。

--- a/docs/research-loom/ideas/index.md
+++ b/docs/research-loom/ideas/index.md
@@ -2,6 +2,7 @@
 
 我认可的思路与自己的新念头，每条一卡：**用自己的话、原子化、引用所凭的来源卡**。永久笔记不是论文摘要，是你的主张。方法见 [`../../design/research-loom.md`](../../design/research-loom.md)。
 
+- 🧭 **[核心理念：在动态工作中积累并验证经验，而非定期收集 eval 跑进化](dynamic-validation-lifecycle.md)** — `候选`（user 倡导为核心理念；把离线 replay 从裁决轴降为兜底，重开决策，待复核）
 - [结构化把关，不要 held-out 分数](structural-gate-no-oracle.md) — `候选`（走通样例，待复核）
 - [要可靠生效的规则，走 hook 强制注入](hook-forced-injection.md) — `候选`（源于 ECC 实测，待复核）
 - [维护层只能叠加，不得改写原生 skill 体验](additive-over-native-skill.md) — `候选`（user 提出的产品边界，待复核）

--- a/docs/research-loom/synthesis/offline-validation.md
+++ b/docs/research-loom/synthesis/offline-validation.md
@@ -55,3 +55,5 @@ type: direction
 **代价（整族命门）**：都重——SkillOpt/EvoSkill/Self-Harness 跑 held-out、RHO 每候选 re-solve G×、MOSS 重放失败批、SkillGen 每实例 2× 跑。实验预算极易爆，故 [探索坍缩](../sources/papers/apex.md) / [非单调遗忘](../sources/papers/self-evolving-forget.md) 的回滚 + 预算封顶在此是一等公民；与轻量结构门组合是压成本的关键。
 
 **wedge**：autoharness 取**子类②**的自举 replay，但移植**子类①**的循环骨架（weakness-mine→minimal edit→regression-gate）——把回归测试纪律套到 harness 演化：每次编辑在自有历史（尤其失败）建的 replay 集上**可验证地净改善**、且**最小/可审计/可回滚**，同时给实验预算封顶。
+
+> **重开提示**：[动态验证生命周期](../ideas/dynamic-validation-lifecycle.md) 主张验证随交互**就地发生**、历史 eval 因**环境漂移**失效，据此把本方向从「裁决轴」降为「兜底」（只在高风险、或结构 + 动态都拿不准时动用）。该卡重开此处地位，待开决策工作表。


### PR DESCRIPTION
The **thesis-level core idea** the user advocates, landed as an idea card, with its reordering of the existing adjudication axes made explicit (no silent changes).

## The idea

The **accumulation and validation of experience both happen in place, alongside the dynamic work as interactions occur** (in-the-loop), rather than "periodically collect an eval set → run an offline evolution pass". Rationale: the environment **drifts with every interaction**, making history-trace-based evals stale and historical grounds invalid. So validation must be **on-demand**; a symbol earns survival by **continuing to be adhered to / effective across real subsequent interactions**; the historical grounds themselves decay with the environment and retire, rather than being permanent golden references.

## Reordering the three gates (where this card lands)

- **Admission (instant · cheap)** = structural gate
- **Survival (continuous · primary)** = **dynamic validation** (promotes `adherence-driven-curate`'s ECC-adherence idea from an "upgrade axis" to a core mechanism)
- **Backstop (heavy · occasional)** = offline replay (only for high-risk / when both structural and dynamic are uncertain)

## Impact: reopen `offline-validation`

This card demotes offline replay from autoharness's "adjudication axis (lands in subtype ②)" to a "backstop" — directly reopening that already-adopted direction. `synthesis/offline-validation.md` now carries a backlink "reopen note" and is marked **pending decision worksheet** (no decision made in this PR; only establishes the idea + flags the tension).

## Checks

- `python3 tools/check_research_loom.py docs/research-loom` → **ok**
- No new dangling links introduced (the `design/research-loom.md` at index.md:3 is a pre-existing dangler).

> Note: independent of PR #16 (provenance permissions); branched from `main` (PR #15 already merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)