### PR TITLE
docs: review fixes (intent_queue + D–G) + README + LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 ryan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,67 @@
+# autoharness
+
+**A per-symbol maintenance optimizer for an agent's skill layer — it learns skills from real
+runs and lets them earn their keep by being *adhered to in use*, not by an offline eval score.**
+
+autoharness watches a host agent's own sessions, distills each episode into a skill, and lands it
+into the native skill directory (`.claude/skills`) where the host recalls it normally. Skills that
+keep getting invoked survive; ones that go unused or get contradicted are archived. It runs as a
+**pure-additive, zero-daemon Claude Code plugin** — it never touches the host's skill load/recall
+path, only observes via hooks and writes to disk.
+
+Closest neighbor is [Hermes-Agent](https://github.com/NousResearch/Hermes-Agent); the wedge:
+Hermes ages skills out on a wall-clock timer behind a resident daemon. autoharness has **no daemon**
+(lazy `SessionStart` recompute) and judges symbols by **invocation rate**, not elapsed time — so on
+ephemeral hosts a skill is never punished for "never had the chance to be used."
+
+> **Status: design-stage.** The architecture is settled and documented; the plugin is not built yet.
+> No install path exists today — see [docs/](docs/index.md) for the design, [docs/plans/roadmap.md](docs/plans/roadmap.md) for the build order.
+
+---
+
+## How it works
+
+A learning pipeline runs *beside* the host. The host's native skill recall is untouched.
+
+| Component | Role |
+|---|---|
+| **CAP** capture | Hook-driven dumb pipe: grabs each turn (user input + agent output + tool I/O), redacts at egress, points back at the host log instead of copying it. |
+| **REF** reflect | At an episode boundary, **compare-first**: reads the existing skill index, decides add / merge / patch / delete, and emits an *intent* (body or delta + reason/evidence). It can only propose — it has no write tools. |
+| **promoter** validate·store | The only writer. Shapes the intent in memory, runs a deterministic linter (safety, structure, ledger, completeness, self-authored-only), and **only on pass** does an atomic rename into the live skill dir. **Validate-before-any-write** — nothing hits disk until it's clean. |
+| **MNG** lifecycle | Deterministic, daemon-free. Ranks symbols by invocation rate per provenance layer; protects new ones (probation), archives the weakest when a mature pool is over capacity. Archives, never deletes. |
+| **LED** ledger | Per-symbol append-only sidecar: why each symbol was born/changed, with evidence and a reflection watermark. Kept out of the skill body so recall stays clean. |
+
+```
+┌─── host agent (host-agnostic) — autoharness is pure-additive, zero-intrusion ───┐
+│   session runs   ·   native skill recall (.claude/skills; name+desc → recall)   │
+└──┬───────────────────────────────────────────────────────────────────▲─────────┘
+   │ CAP: hooks observe                              symbols = native skills, host recalls them
+   ▼                                                                     │
+ CAP capture ──► REF reflect (compare-first, ──► promoter (admission: validate in memory,
+ (hooks)         emits intent, no write tools)    atomic write on pass) ─┘
+   │ trace pointer                                      │ append LED
+   ▼                                          MNG lifecycle      LED ledger (sidecar)
+ [host log]
+```
+
+**Invariants:** pure-additive / zero-intrusion · author ≠ validator (REF proposes, a deterministic
+linter gates) · precise & safe → deterministic, judgment → LLM · validate-before-any-write ·
+model only proposes, landing is the promoter's alone.
+
+The final shape is a **single Claude Code plugin**: one copy of the code, execution only from the
+plugin's hook layer, and only data/state split global vs repo. See [docs/research-loom/design/architecture.md](docs/research-loom/design/architecture.md).
+
+## Documentation
+
+| | |
+|---|---|
+| [docs/](docs/index.md) | Documentation map — single entry point. |
+| [design spine](docs/research-loom/design/spine.md) | Principle + pipeline + global invariants + architecture diagram. |
+| [architecture](docs/research-loom/design/architecture.md) | Code structure / file tree of the plugin. |
+| [research-loom](docs/research-loom/index.md) | The literature→design workspace: every cited source, synthesized into the design across five provenance-linked layers. |
+| [roadmap](docs/plans/roadmap.md) | Implementation roadmap, test strategy, CI gates. |
+| [TODO](docs/TODO.md) | Tracked follow-ups. |
+
+## License
+
+[MIT](LICENSE).

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -5,9 +5,6 @@
 
 - [ ] **Measure interrogative-filter precision at scale** (Phase 2 entry). E2 sampled precision
   by hand (~5% → ~50%); needs a labelled measurement across projects under `experiments/`.
-- [ ] **Applicability-estimator calibration** (Phase 2 entry). The omission denominator
-  (`docs/design/attribute.md`) is unvalidated — calibrate against held-out adherence the user
-  confirms before any prose-rule omission verdict ships.
 - [ ] **Locate the commit-signature instruction symbol.** E3's conflict case needs its source
   symbol identified (system prompt / settings / output-style) so Phase 0 can target the override.
 - [ ] **Resolve the live signature conflict for this repo.** The harness instruction to add

--- a/docs/plans/roadmap.md
+++ b/docs/plans/roadmap.md
@@ -30,15 +30,16 @@
 - subagent 自带 `PreToolUse` hook 是否对其自身工具调用生效；deny 的确切协议（exit code vs JSON）（[reflector-subagent](../research-loom/design/reflector-subagent.md)）。
 - `--agent` 省略 `tools` 是否全继承；plugin 内 `plugin:reflector` 能否被 hook spawn 解析（[reflector-subagent](../research-loom/design/reflector-subagent.md)）。
 - learned skill 被用是否走 `Skill` 工具、触发 `PreToolUse(Skill)`，payload 是否带解析后符号身份（[mng](../research-loom/design/mng.md)，率分子前提）。
+- `Stop` 触发与 API 请求是否一一对应——定清「一次请求」（一个 turn 多次模型调用 / 重试各算几次），锁定 MNG 分母粒度（[mng](../research-loom/design/mng.md)，率分母前提）。
 - session-id→transcript 发现充分；compaction 下 tail-N 取到原始轮次（[cap](../research-loom/design/cap.md)）。
 
 **测试方法**：手点 / 脚本 harness 在真 Claude Code 上跑，每项落 `experiments/` 一条 evidence；**不进 CI**。**退出条件**：每个 spike 有 yes/no + 投递决策。
 
 ## Phase 1 — config + `lib/` write-once 原语（地基）
 
-`config.py` 单点（节奏 / 成熟阈值 / 上限分层 / 红线集 + format_spec 指针）+ `layer` / `skill_store` / `sidecar` / `ledger` / `counters` / `redact` / `validate` / `skills_guard` / `intent_queue`。最底层、全管道复用、纯确定性。
+`config.py` 单点（节奏 / 成熟阈值 / 上限分层 / 红线集 + format_spec 指针）+ `layer` / `skill_store` / `sidecar` / `ledger` / `counters` / `redact` / `validate` / `skills_guard` / `intent_queue`。最底层、全管道复用、纯确定性。**契约数据本身也是本 Phase 交付物、非只建消费者**：`format_spec`（必填结构 spec，REF 写 + #416 验同源）、`redaction_rules`（secret/PII 规则集，CAP egress + LED 同源）。
 
-**测试（unit）**：`layer` 由入参解析两层落盘位；`skill_store` 原子写 + 两层 `find` + 应用 delta；`sidecar` 单实现读写 created_by/计数/verification；`ledger` append-only（只增不改）；`intent_queue` append / drain / 启动 sweep 孤儿（writer=stage_skill、reader=promoter 同源一份）；`counters` 按层分子分母、O(1) 读改写；`redact` 红线消费（窗口切片 / LED 证据出口）；`validate` 六类 linter 跑在内存成型结果上；`skills_guard` 六族正则（exfiltration/injection/destructive/persistence/network/obfuscation）。**红队**：`skills_guard` 挡投毒 / 指令型注入；`redact` 不漏 PII / secret；global 含 repo-local 标识被 `validate` 降级或 reject。
+**测试（unit）**：`layer` 由入参解析两层落盘位；`skill_store` 原子写 + 两层 `find`（同名跨两层→报错消歧）+ 应用 delta；`sidecar` 单实现读写 created_by/计数/verification；`ledger` append-only（只增不改）；`intent_queue` append / drain / 启动 sweep 孤儿（writer=stage_skill、reader=promoter 同源一份）；`counters` 按层分子分母、O(1) 读改写；`redact` 红线消费（窗口切片 / LED 证据出口）；`validate` 六类 linter 跑在内存成型结果上；`skills_guard` 六族正则（exfiltration/injection/destructive/persistence/network/obfuscation）。**红队**：`skills_guard` 挡投毒 / 指令型注入；`redact` 不漏 PII / secret；global 含 repo-local 标识被 `validate` 降级或 reject。
 
 ## Phase 2 — promoter 校验·存储（admission 闸 + 原子落盘）★安全 chokepoint
 
@@ -98,3 +99,4 @@
 - Phase 0 的 spike 结论门禁 Phase 3/5/6 的 live 部分与投递形态；其确定性部分（schema、拼装、率算）不等 spike、可先建先测。
 - CI 只跑确定性 + 管道（unit+system），live 全排除——**确定性侧零外部依赖即可全绿**，是合并门禁的实际内容。
 - config 标定值（成熟阈值 / 上限 / `reflect_every_n`）经验标定走 `experiments/`，测试断言关系不断绝对值。
+- **范围声明**：遵守度（adherence，[spine](../research-loom/design/spine.md) 的未建核心论点）**不在 Phase 0–7**、留后；本 roadmap 只覆盖 v1 的捕获 / 反思 / 准入 / 生命周期闭环。

--- a/docs/plans/roadmap.md
+++ b/docs/plans/roadmap.md
@@ -36,9 +36,9 @@
 
 ## Phase 1 — config + `lib/` write-once 原语（地基）
 
-`config.py` 单点（节奏 / 成熟阈值 / 上限分层 / 红线集 + format_spec 指针）+ `layer` / `skill_store` / `sidecar` / `ledger` / `counters` / `redact` / `validate` / `skills_guard`。最底层、全管道复用、纯确定性。
+`config.py` 单点（节奏 / 成熟阈值 / 上限分层 / 红线集 + format_spec 指针）+ `layer` / `skill_store` / `sidecar` / `ledger` / `counters` / `redact` / `validate` / `skills_guard` / `intent_queue`。最底层、全管道复用、纯确定性。
 
-**测试（unit）**：`layer` 由入参解析两层落盘位；`skill_store` 原子写 + 两层 `find` + 应用 delta；`sidecar` 单实现读写 created_by/计数/verification；`ledger` append-only（只增不改）；`counters` 按层分子分母、O(1) 读改写；`redact` 红线消费（窗口切片 / LED 证据出口）；`validate` 六类 linter 跑在内存成型结果上；`skills_guard` 六族正则（exfiltration/injection/destructive/persistence/network/obfuscation）。**红队**：`skills_guard` 挡投毒 / 指令型注入；`redact` 不漏 PII / secret；global 含 repo-local 标识被 `validate` 降级或 reject。
+**测试（unit）**：`layer` 由入参解析两层落盘位；`skill_store` 原子写 + 两层 `find` + 应用 delta；`sidecar` 单实现读写 created_by/计数/verification；`ledger` append-only（只增不改）；`intent_queue` append / drain / 启动 sweep 孤儿（writer=stage_skill、reader=promoter 同源一份）；`counters` 按层分子分母、O(1) 读改写；`redact` 红线消费（窗口切片 / LED 证据出口）；`validate` 六类 linter 跑在内存成型结果上；`skills_guard` 六族正则（exfiltration/injection/destructive/persistence/network/obfuscation）。**红队**：`skills_guard` 挡投毒 / 指令型注入；`redact` 不漏 PII / secret；global 含 repo-local 标识被 `validate` 降级或 reject。
 
 ## Phase 2 — promoter 校验·存储（admission 闸 + 原子落盘）★安全 chokepoint
 

--- a/docs/research-loom/design/architecture.md
+++ b/docs/research-loom/design/architecture.md
@@ -41,6 +41,7 @@ autoharness/                         # plugin 根（装到 ~/.claude/plugins/cac
         ├── validate.py              #   确定性 linter 六类（含自产标签）
         ├── skills_guard.py          #   安全正则扫描
         ├── redact.py                #   egress 红线集消费者
+        ├── redaction_rules.toml     #   secret/PII 规则集数据：CAP egress 与 LED 共用单一来源（config 指向、redact 消费）
         └── format_spec.md           #   authoring / lint 单一契约（REF 按它写、linter 按它验）
 ```
 

--- a/docs/research-loom/design/architecture.md
+++ b/docs/research-loom/design/architecture.md
@@ -35,6 +35,7 @@ autoharness/                         # plugin 根（装到 ~/.claude/plugins/cac
         ├── skill_store.py           #   skill CRUD：原子写 + 两层 find + 应用 delta
         ├── sidecar.py               #   sidecar 读写：created_by / 计数 / verification（单一实现）
         ├── ledger.py                #   LED append-only
+        ├── intent_queue.py          #   per-run intent 队列：append(stage_skill)/ drain(promoter)/ 启动 sweep 孤儿（持久策略见 validate-store 待解，先最小）
         ├── counters.py              #   CAP 会话计数 + MNG 分子 / 分母（单一实现、按层）
         ├── lifecycle.py             #   MNG：率 + 缓刑 + 容量竞争
         ├── validate.py              #   确定性 linter 六类（含自产标签）
@@ -71,8 +72,8 @@ autoharness/                         # plugin 根（装到 ~/.claude/plugins/cac
 |---|---|---|
 | CAP 捕获 | `hook/{on_stop,on_session_end,capture}` + `lib/{counters,redact}` | [cap](cap.md) |
 | REF 反思 | `agents/reflector.md`（定义） | [ref](ref.md) · [reflector-subagent](reflector-subagent.md) |
-| stage_skill | `stage_skill/server.py` + 复用 `lib/{skill_store,validate}` | [stage-skill](stage-skill.md) |
-| 校验·存储 | `hook/promoter.py` + `lib/{skill_store,validate,skills_guard,ledger,sidecar}` | [validate-store](validate-store.md) |
+| stage_skill | `stage_skill/server.py` + 复用 `lib/{skill_store,validate,intent_queue}` | [stage-skill](stage-skill.md) |
+| 校验·存储 | `hook/promoter.py` + `lib/{skill_store,validate,skills_guard,ledger,sidecar,intent_queue}` | [validate-store](validate-store.md) |
 | MNG 生命周期 | `hook/on_session_start.py` + `lib/{lifecycle,counters,sidecar}` | [mng](mng.md) |
 | LED 账本 | `lib/{ledger,sidecar}` | （per-module 待补） |
 


### PR DESCRIPTION
Following the merge of #22/#23, this opens a new PR for the review fixes and repo wrap-up accumulated on this branch.

## Contains 3 commit groups
1. **B — intent_queue placement**: `lib/intent_queue.py` becomes the single owner of the intent queue (stage_skill writes / promoter reads from one shared source, removing duplication); architecture.md + roadmap Phase 1 updated to match.
2. **D–G — roadmap closeout**:
   - D denominator definition spike (whether `Stop` == one API request) added to Phase 0
   - E adherence scope declaration (not in Phase 0–7, deferred)
   - F contract data listed as a deliverable + redline set placed in `lib/redaction_rules.toml`
   - G skill_store two-layer `find` gains a "same name across both layers → raise to disambiguate" test
3. **Repo wrap-up**: README + LICENSE (MIT); TODO cleanup of calibrated items.

Note: consistency of the six categories (including self-produced labels) was already closed out by the author during the #22/#23 phase; this PR does not touch it.

## Verification
Both `check_doc_links` and `check_research_loom` green.
