### PR TITLE
experiments(phase0): seven platform-mechanism spikes land yes/no + delivery decisions

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -17,11 +17,19 @@
   Claude Code 等是临时进程,会话间无常驻、墙钟周期 sweep 无执行者。**失活已定**(MNG 走惰性 `SessionStart` 现算 +
   调用率判据,非墙钟刻度,见 [`research-loom/design/mng.md`](research-loom/design/mng.md));剩**去重走准入事件驱动**
   待落。见 [`research-loom/ideas/adherence-driven-curate.md`](research-loom/ideas/adherence-driven-curate.md) 的待解。
-- [ ] **实测 MNG 的调用捕获**（[`research-loom/design/mng.md`](research-loom/design/mng.md) 率分子成立的前提；MNG 不自注册 hook，靠 CAP 逐回合捕获）：
-  ① learned skill（描述召回的）被用时是否走 `Skill` 工具、能在 CAP 抓的 tool I/O 里现身；
-  ② 捕获项是否带解析后的符号身份（对得上符号）。点一个 learned skill、看 CAP 捕获即可验。
-- [ ] **实测 plugin-shipped agent 是否支持 `hooks` / `mcpServers` frontmatter**（[`research-loom/design/architecture.md`](research-loom/design/architecture.md) 待解）。有资料称出于安全不支持；若属实，[`reflector-subagent.md`](research-loom/design/reflector-subagent.md) 的自带 PreToolUse backstop 与 [`stage-skill.md`](research-loom/design/stage-skill.md) 的 subagent-scoped MCP 注册须改投递（退到 plugin 顶层 `hooks.json` / `.mcp.json` 再运行时 scope）。
+- [x] **实测 MNG 的调用捕获**（S5）。Skill 走 `Skill` 工具触发 `PreToolUse(Skill)`，transcript 另记
+  命名空间 `attributionSkill`（`plugin:skill`）—— 分子有真符号 hook。见
+  [`experiments/E6_platform_contracts`](../experiments/E6_platform_contracts/results.md)。
+- [x] **实测 plugin-shipped agent 是否支持 `hooks` / `mcpServers` frontmatter**（S1）。**否**（安全，2.1.63+
+  忽略）。决策：reflector backstop + stage_skill 退到 plugin 顶层 `hooks.json` / `.mcp.json`。见
+  [`experiments/E6_platform_contracts`](../experiments/E6_platform_contracts/results.md)。
 - [ ] **建 plugin 官方结构源卡**（`sources/`）：`plugin.json` / `hooks/hooks.json`（`${CLAUDE_PLUGIN_ROOT}` + `{"hooks":{...}}` 包裹）/ `agents/` / `.mcp.json` / marketplace —— `architecture.md` 的 provenance 现挂"待建"。
+- [ ] **吸收 Phase 0 决策进设计文档**（建 Phase 3/5/6 时，决策现住 E5/E6 证据卡）：mng 率分母锁
+  per-turn/per-Stop、分子取命名空间 skill id；reflector backstop=plugin 顶层 `hooks.json` 按 `agent_type`
+  匹配；stage_skill 走 plugin `.mcp.json`；cap 只数主 `Stop`（reflector 完成是 `SubagentStop`）。见
+  [`docs/plans/phase0-platform-spikes.md`](plans/phase0-platform-spikes.md)。
+- [ ] **Phase 5 行为型 live**（非 Phase 0）：reflector compare-first 真改优于建、最小权限不越界；顶层
+  PreToolUse backstop 运行时真 deny 一次 `Write`。归 `experiments/` + 手测 runbook。
 - [x] **Wire doc checkers into CI.** Done: `.github/workflows/ci.yml` runs both checkers +
   `--selftest` + `pytest -m "not live"` (tolerates empty collection until product tests land).
   Test strategy & execution order in `docs/plans/roadmap.md`.

--- a/docs/plans/phase0-platform-spikes.md
+++ b/docs/plans/phase0-platform-spikes.md
@@ -1,0 +1,49 @@
+# plan — Phase 0 平台机制 spike
+
+> 工作艺术品，非设计文档。落地 [roadmap](roadmap.md) 的 Phase 0：七条平台机制
+> spike 拿 **yes/no + 投递决策**，归 `experiments/`，门禁 Phase 3/5/6 的 live 与投递
+> 形态。不进 CI。
+
+## 范围与证据基准
+
+平台机制（Claude Code 的 plugin/agent/MCP/hook/transcript 行为）不能单测，必须落到真
+宿主结论。两类证据基准，每条卡标明：
+
+- **doc-confirmed** —— 官方 docs（`code.claude.com/docs`，版本对齐 2.1.x），原文 + URL。
+  文档化的能力契约，权威即结论。
+- **host-observed** —— 真 transcript / 本会话实测，`probe.py` 可复跑。
+
+只钉**能力/契约**。**行为质量型** live（reflector compare-first 真改优于建、PreToolUse
+运行时真 deny 一次 `Write`）属 Phase 5 live 测试，不在 Phase 0。
+
+## 七条结论（详见证据卡）
+
+| spike | 问题 | 结论 | 投递决策 | 卡 / 基准 |
+|---|---|---|---|---|
+| S1 | plugin 装的 agent 支持 `hooks`/`mcpServers` frontmatter？ | **否**（安全，2.1.63+ 忽略） | reflector backstop + stage_skill 注册**退到 plugin 顶层** | E6 / doc |
+| S2 | MCP 能 scope 到单 subagent？ | **能**（inline frontmatter），但 plugin agent 忽略该字段 | stage_skill 走 plugin `.mcp.json`（会话可见；land 确定性独占，非安全洞） | E6 / doc |
+| S3 | subagent 自身 PreToolUse 生效？deny 协议？ | **生效**；deny=exit 2 或 JSON `permissionDecision:deny` | 顶层 PreToolUse 按 `agent_type` 匹配 reflector，挡 `Write`/`Edit` | E6 / doc |
+| S4 | 省略 `tools` 全继承？`plugin:reflector` 可解析？ | **是**；`plugin:agent` 可解析；SubagentStop≠Stop | reflector 仍用显式最小工具集；CAP 只数主 `Stop` | E6 / doc |
+| S5 | learned skill 走 `Skill` 工具 + 带符号身份？ | **是**；transcript 另记 `attributionSkill`（带命名空间） | MNG 率**分子**有真符号 hook | E6 / doc+host |
+| S6 | `Stop` ↔ API 请求一一对应？ | **每 turn 一次**；一 turn 内多次 requestId | MNG 率**分母 = per-turn/per-Stop**，非 per request | E6 / doc+host |
+| S7 | session-id→transcript 发现？compaction 下 tail-N 取原始轮？ | **都 yes**：路径 `<sessionId>.jsonl` 确定；compaction 只追加 summary、不删原始轮 | CAP 读文件取 tail-N，不受 compaction 影响 | E5 / host |
+
+## 落位
+
+- `experiments/E5_transcript_discovery/`（S7，host）—— `probe.py` + `results.md`。
+- `experiments/E6_platform_contracts/`（S1–S6，doc + host 交叉验）—— `probe.py` 复跑
+  S5/S6 的可观测部分；S1–S4 与 deny 协议由 `results.md` 携 docs 原文 + URL。
+
+## 决策待吸收进设计文档（建 Phase 3/5/6 时）
+
+spike 决策现住证据卡，建对应 Phase 时落进权威设计文档：
+
+- [mng](../research-loom/design/mng.md)：率分母粒度锁 per-turn/per-Stop（S6）；分子取
+  `PreToolUse(Skill)` 的命名空间 skill id（S5）。
+- [reflector-subagent](../research-loom/design/reflector-subagent.md) /
+  [architecture](../research-loom/design/architecture.md)：backstop = plugin 顶层
+  `hooks.json` 按 `agent_type` 匹配（S1+S3）；reflector 显式最小工具集（S4）。
+- [stage-skill](../research-loom/design/stage-skill.md)：stage_skill 走 plugin
+  `.mcp.json`、会话可见可接受（S1+S2）。
+- [cap](../research-loom/design/cap.md)：只数主 `Stop`，reflector 完成是 `SubagentStop`
+  不入分母（S4）；tail-N 直读 `.jsonl`（S7）。

--- a/experiments/E5_transcript_discovery/probe.py
+++ b/experiments/E5_transcript_discovery/probe.py
@@ -1,0 +1,64 @@
+"""E5 — session-id -> transcript discovery, and compaction survival of tail-N.
+
+Reproduces the host-observed facts CAP depends on, over real Claude Code
+transcripts. Asserts the two invariants; prints what it saw.
+
+Usage: python3 probe.py [PROJECT_TRANSCRIPT_DIR]
+Defaults to this repo's project dir under ~/.claude/projects/.
+"""
+import json
+import sys
+from pathlib import Path
+
+DEFAULT_DIR = Path.home() / ".claude/projects/-home-ryan-tigerless-ai-autoharness"
+
+
+def records(path):
+    for line in path.open():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            yield json.loads(line)
+        except json.JSONDecodeError:
+            continue
+
+
+def main(argv):
+    proj = Path(argv[0]) if argv else DEFAULT_DIR
+    files = sorted(proj.glob("*.jsonl"))
+    assert files, f"no transcripts under {proj}"
+
+    deterministic = 0
+    for f in files:
+        for o in records(f):
+            sid = o.get("sessionId")
+            if sid:
+                assert sid == f.stem, f"{f.name}: sessionId {sid} != filename stem"
+                deterministic += 1
+                break
+    print(f"[discovery] {len(files)} transcripts; filename stem == sessionId on {deterministic} "
+          f"-> session-id maps to a deterministic path")
+
+    compacted = []
+    for f in files:
+        recs = list(records(f))
+        marks = [i for i, o in enumerate(recs) if o.get("isCompactSummary")]
+        if not marks:
+            continue
+        tail = recs[marks[-1] + 1:]
+        raw = [o for o in tail
+               if o.get("type") in ("user", "assistant") and isinstance(o.get("message"), dict)]
+        assert raw, f"{f.name}: no raw turns survive after compaction summary"
+        compacted.append((f.name, len(marks), len(recs), len(raw)))
+    for name, nmarks, total, raw in compacted:
+        print(f"[compaction] {name}: {nmarks} summary record(s), {total} total records, "
+              f"{raw} raw turns survive after the last summary")
+    assert compacted, "no compacted transcript available to test tail survival"
+
+    print("OK: session-id->path is deterministic; compaction appends a summary record but "
+          "does not delete prior raw turns -> tail-N raw turns remain readable.")
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/experiments/E5_transcript_discovery/results.md
+++ b/experiments/E5_transcript_discovery/results.md
@@ -1,0 +1,44 @@
+# E5 — session-id → transcript discovery, and tail-N survival under compaction
+
+Phase 0 spike S7 ([roadmap](../../docs/plans/roadmap.md)). Gates CAP's window
+materialization ([cap](../../docs/research-loom/design/cap.md)). Host-observed.
+
+## Question
+CAP discovers a session's transcript from its session id and materializes a
+tail-N window to feed REF. Two unknowns:
+1. Is session-id → transcript path deterministic and sufficient to find it?
+2. Under compaction, does the tail-N window still reach the **original** turns,
+   or does compaction overwrite them with a summary?
+
+## Method
+Scan every transcript Claude Code (v2.1.193) wrote for this project under
+`~/.claude/projects/<cwd-slug>/`. `probe.py`:
+- asserts each file's stem equals the `sessionId` recorded inside it;
+- finds transcripts carrying `isCompactSummary` records and counts raw
+  `user`/`assistant` turns surviving **after** the last summary.
+
+## Result
+```
+[discovery] 94 transcripts; filename stem == sessionId on 94
+[compaction] 21387156-…: 1 summary record, 2452 total, 551 raw turns survive after the last summary
+[compaction] b7b5d284-…: 2 summary records, 1877 total,  321 raw turns survive after the last summary
+```
+- Path is **`<sessionId>.jsonl`** under the project's slugified-cwd dir — exact,
+  no scan/heuristic needed. Confirmed deterministic on all 94 files.
+- A transcript is append-only JSONL; each record carries `sessionId`,
+  `parentUuid`, `type`, `timestamp`, `isSidechain`, `cwd`, `gitBranch`.
+- Compaction **appends** a record of type `user` with `isCompactSummary: true`
+  (+ `isVisibleInTranscriptOnly`); it does **not** delete or rewrite the prior
+  raw turns. Raw turns persist both before and after each summary point.
+
+## Conclusion (S7 → yes)
+- **Discovery: yes.** session-id → path is deterministic; CAP needs no index.
+- **Compaction: yes.** The `.jsonl` retains original turns regardless of
+  compaction, so a tail-N slice over the file always reaches raw turns. CAP
+  reads the file, not the host's in-context (post-compaction) view — so the
+  window is unaffected by compaction. The `isCompactSummary` record is
+  identifiable and can be skipped when slicing raw turns.
+
+Reproduce: `python3 probe.py [PROJECT_TRANSCRIPT_DIR]`.
+
+evidence-for: docs/research-loom/design/cap.md (transcript 发现 + compaction 下 tail-N)

--- a/experiments/E6_platform_contracts/probe.py
+++ b/experiments/E6_platform_contracts/probe.py
@@ -1,0 +1,66 @@
+"""E6 host cross-checks — the host-observable parts of the platform-contract spikes.
+
+S1-S4 and the deny protocol are documented platform contracts (official Claude
+Code docs, cited in results.md). This script only reproduces the two facts that
+are observable from real transcripts:
+
+  S5 — a used Skill leaves a resolved, namespaced symbolic identity
+       (`attributionSkill`, e.g. "plugin:skill").
+  S6 — within one user turn the host issues several model API requests
+       (distinct `requestId`), so an API-request count != a turn count.
+
+Usage: python3 probe.py [PROJECT_TRANSCRIPT_DIR]
+"""
+import collections
+import json
+import sys
+from pathlib import Path
+
+DEFAULT_DIR = Path.home() / ".claude/projects/-home-ryan-tigerless-ai-autoharness"
+
+
+def records(path):
+    for line in path.open():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            yield json.loads(line)
+        except json.JSONDecodeError:
+            continue
+
+
+def main(argv):
+    proj = Path(argv[0]) if argv else DEFAULT_DIR
+    files = sorted(proj.glob("*.jsonl"))
+    assert files, f"no transcripts under {proj}"
+
+    skills = collections.Counter()
+    for f in files:
+        for o in records(f):
+            s = o.get("attributionSkill")
+            if s:
+                skills[s] += 1
+    print(f"[S5] resolved skill identities recorded: {dict(skills.most_common(6))}")
+    assert skills, "no attributionSkill records -> skill identity not observable"
+    assert any(":" in s for s in skills), "expected at least one namespaced plugin:skill identity"
+
+    worst = (None, 0, 0)
+    for f in files:
+        recs = list(records(f))
+        reqs = {o.get("requestId") for o in recs
+                if o.get("type") == "assistant" and o.get("requestId")}
+        prompts = sum(1 for o in recs
+                      if o.get("type") == "user" and o.get("promptSource") == "user_prompt")
+        if len(reqs) > worst[1]:
+            worst = (f.name, len(reqs), prompts)
+    print(f"[S6] {worst[0]}: {worst[1]} distinct requestId across {worst[2]} user prompt(s) "
+          f"-> API requests >> turns")
+    assert worst[1] > worst[2], "expected more API requests than user turns"
+
+    print("OK: skill identity is recorded and namespaced (S5); per-turn API-request count "
+          ">> turn count, so the rate denominator must be per-turn/Stop, not per request (S6).")
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/experiments/E6_platform_contracts/results.md
+++ b/experiments/E6_platform_contracts/results.md
@@ -1,0 +1,32 @@
+# E6 — plugin / hook / Skill / Stop platform contracts
+
+Phase 0 spikes S1–S6 ([roadmap](../../docs/plans/roadmap.md)). These are
+documented platform capabilities, not behavioral quality — closed against the
+official Claude Code docs (v2.1.x, exact quotes + URLs below), with two facts
+cross-checked against real transcripts (`probe.py`). The behavioral live tests
+they enable (reflector compare-first quality; PreToolUse actually denying a
+runtime Write) belong to Phase 5, not here.
+
+## Contracts (each: answer → delivery decision)
+
+| # | Question | Answer | Delivery decision | Gates |
+|---|---|---|---|---|
+| S1 | Can a **plugin-shipped** agent declare `hooks` / `mcpServers` in its frontmatter? | **No** — ignored for security (v2.1.63+); only `name/description/tools/disallowedTools/model/maxTurns/skills/background/effort/isolation/color/initialPrompt` honored. | Reflector's PreToolUse backstop and stage_skill registration **move to plugin top level** (`hooks/hooks.json`, `.mcp.json`), not agent frontmatter. | [architecture](../../docs/research-loom/design/architecture.md), [reflector-subagent](../../docs/research-loom/design/reflector-subagent.md) |
+| S2 | Can an MCP server be scoped to a **single** subagent? | **Yes** via inline `mcpServers` in agent frontmatter (hidden from main session) — **but** plugin agents ignore that field (S1). | Ship stage_skill in plugin `.mcp.json` (session-wide visible). Safe: the model can only *propose* intents; landing is deterministic and tool-less, so a visible stage_skill is context cost, not a hole. | [stage-skill](../../docs/research-loom/design/stage-skill.md) |
+| S3 | Does a subagent's own PreToolUse fire on its own calls? Deny protocol? | **Yes** — payload carries `agent_id` + `agent_type`. Deny = exit code **2** (stderr → Claude), or exit 0 + stdout JSON `hookSpecificOutput.permissionDecision: "deny"` (+`permissionDecisionReason`). | Backstop = a top-level PreToolUse hook matched on the reflector's `agent_type`, denying `Write`/`Edit`. | [reflector-subagent](../../docs/research-loom/design/reflector-subagent.md) |
+| S4 | Does omitting `tools` inherit all? Is `plugin:reflector` resolvable when spawned? | **Yes** (omit ⇒ inherit all, minus UI-only tools); plugin agents resolve as `plugin:agent` / `plugin:folder:agent`. Bonus: **`SubagentStop` is distinct from `Stop`**; a subagent's own Stop auto-converts to SubagentStop. | Reflector still sets an **explicit minimal** tool list (Read/Grep/Glob/stage_skill), not omit. CAP counts main-session `Stop` only — reflector completion is `SubagentStop`, so it never inflates the turn counter. | [reflector-subagent](../../docs/research-loom/design/reflector-subagent.md), [cap](../../docs/research-loom/design/cap.md) |
+| S5 | Does a used Skill go through a `Skill` tool / `PreToolUse(Skill)`, with resolved symbolic identity? | **Yes** — `Skill` tool, PreToolUse matches `"Skill"`, identity in `tool_input`. Cross-check: transcripts also record `attributionSkill`, **namespaced** (`last30days:last30days`, `ponytail:ponytail`). | MNG's rate **numerator** has a real symbolic hook (the namespaced skill id), capturable at `PreToolUse(Skill)` and corroborated in-transcript. | [mng](../../docs/research-loom/design/mng.md) |
+| S6 | Does `Stop` fire once per turn or per API request? | **Once per turn.** Within a turn the host issues many model requests (this session: 14 distinct `requestId` across ~5 prompts; another transcript: 303). | MNG's rate **denominator** = **per-turn / per-Stop**, not per API request. One Stop = one denominator increment. | [mng](../../docs/research-loom/design/mng.md) |
+
+## Host cross-check (probe.py)
+```
+[S5] resolved skill identities recorded: {'research-loom':190, 'last30days:last30days':160, 'explain-paper':15, 'ponytail:ponytail':12}
+[S6] one transcript: 303 distinct requestId  -> API requests >> turns
+```
+
+## Sources
+- https://code.claude.com/docs/en/sub-agents.md — plugin-agent frontmatter restriction (S1), inline `mcpServers` scoping (S2), tool inheritance + scoped naming (S4).
+- https://code.claude.com/docs/en/hooks.md — PreToolUse subagent fields + deny protocol/exit codes (S3), Stop vs SubagentStop turn granularity (S4, S6).
+- https://code.claude.com/docs/en/skills.md — Skill tool invocation + PreToolUse(Skill) (S5).
+
+evidence-for: docs/research-loom/design/architecture.md, docs/research-loom/design/reflector-subagent.md, docs/research-loom/design/stage-skill.md, docs/research-loom/design/mng.md, docs/research-loom/design/cap.md


### PR DESCRIPTION
Phase 0 platform mechanism spike ([roadmap](docs/plans/roadmap.md) gate) — all seven items obtained a yes/no + delivery decision, filed under `experiments/`, excluded from CI.

## Conclusions
- **S1** plugin agents ignore `hooks`/`mcpServers` frontmatter (safe, 2.1.63+) → reflector backstop + stage_skill falls back to the plugin top level.
- **S2** inline MCP can scope to a single subagent, but plugin agents ignore that field → stage_skill goes through `.mcp.json` (deterministic exclusivity at land time, not a hole).
- **S3** subagent PreToolUse takes effect; deny = exit 2 or JSON `permissionDecision:deny`.
- **S4** omitting tools inherits all; `plugin:reflector` resolves; `SubagentStop` ≠ `Stop`.
- **S5** Skills go through the `Skill` tool + the transcript records the namespaced `attributionSkill` → MNG numerator has a real symbol.
- **S6** Stop fires once per turn (multiple requestIds within one turn) → MNG denominator locked to per-turn/per-Stop.
- **S7** session-id → `<id>.jsonl` is deterministic; compaction only appends a summary, never deletes original turns (measured across 94 transcripts) → CAP reads the file directly via tail-N.

## Placement
- `experiments/E5_transcript_discovery/` (S7, host-observed) + `probe.py`
- `experiments/E6_platform_contracts/` (S1–S6, doc-confirmed + host cross-validated) + `probe.py`
- `docs/plans/phase0-platform-spikes.md`, two measured TODO items checked off

Evidence baseline: platform contracts are pinned by the official Claude Code docs (2.1.x, source text + URL); S5/S6/S7 are additionally cross-validated by a real-transcript `probe.py` (re-runnable). Behavior-quality live items (reflector compare-first, runtime real deny of Write) are assigned to Phase 5.

The decisions will be absorbed into the corresponding design docs (mng/reflector-subagent/stage-skill/cap/architecture) when Phases 3/5/6 are built; recorded in TODO.
