### PR TITLE
ci: add ruff lint job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,16 @@ on:
   pull_request:
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install ruff
+      - run: ruff check .
+
   test:
     runs-on: ubuntu-latest
     steps:

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,6 @@
+# lint 配置：选 pyflakes(F) + import 排序(I) + pyupgrade(UP) + bugbear(B) + 关键 pycodestyle
+# (E4/E7/E9)。不收 E501 行长 —— Chinese 注释会超 88、那是噪音非缺陷。
+target-version = "py311"
+
+[lint]
+select = ["E4", "E7", "E9", "F", "I", "UP", "B"]


### PR DESCRIPTION
Adds a second CI job `lint` (a separate check line) that runs `ruff check .`.

- `ruff.toml` pins `select = F, I, UP, B, E4/E7/E9` — pyflakes (unused/undefined) + import sorting + pyupgrade + bugbear (error-prone) + key pycodestyle. **Excludes E501 line length** (Chinese comments over 88 are noise, not defects).
- The whole repo currently passes `ruff check` green; adding this gate introduces no red.
- `target-version = py311` (the project uses `tomllib`, 3.11+).

ponytail: ship ruff only; add mypy/coverage/multi-version matrix etc. when there's a real pain point, not piling on "more checks" for its own sake.
