### PR TITLE
docs(todo): remove completed items + fix validate #416 repo_name already landed

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -17,12 +17,6 @@
   Claude Code 等是临时进程,会话间无常驻、墙钟周期 sweep 无执行者。**失活已定**(MNG 走惰性 `SessionStart` 现算 +
   调用率判据,非墙钟刻度,见 [`research-loom/design/mng.md`](research-loom/design/mng.md));剩**去重走准入事件驱动**
   待落。见 [`research-loom/ideas/adherence-driven-curate.md`](research-loom/ideas/adherence-driven-curate.md) 的待解。
-- [x] **实测 MNG 的调用捕获**（S5）。Skill 走 `Skill` 工具触发 `PreToolUse(Skill)`，transcript 另记
-  命名空间 `attributionSkill`（`plugin:skill`）—— 分子有真符号 hook。见
-  [`experiments/E6_platform_contracts`](../experiments/E6_platform_contracts/results.md)。
-- [x] **实测 plugin-shipped agent 是否支持 `hooks` / `mcpServers` frontmatter**（S1）。**否**（安全，2.1.63+
-  忽略）。决策：reflector backstop + stage_skill 退到 plugin 顶层 `hooks.json` / `.mcp.json`。见
-  [`experiments/E6_platform_contracts`](../experiments/E6_platform_contracts/results.md)。
 - [ ] **建 plugin 官方结构源卡**（`sources/`）：`plugin.json` / `hooks/hooks.json`（`${CLAUDE_PLUGIN_ROOT}` + `{"hooks":{...}}` 包裹）/ `agents/` / `.mcp.json` / marketplace —— `architecture.md` 的 provenance 现挂"待建"。
 - [ ] **吸收 Phase 0 决策进设计文档**（建 Phase 3/5/6 时，决策现住 E5/E6 证据卡）：mng 率分母锁
   per-turn/per-Stop、分子取命名空间 skill id；reflector backstop=plugin 顶层 `hooks.json` 按 `agent_type`
@@ -32,8 +26,7 @@
   PreToolUse backstop 运行时真 deny 一次 `Write`。归 `experiments/` + 手测 runbook。
 - [ ] **validate #416 子查补全**（Phase 2/3）：v1 结构查 = frontmatter + name/description +「被引且存在的
   `.py` 语法解析」；**引用文件存在性 / 断 symlink** 待 intent 带显式文件清单再加（按散文路径串硬查会误杀
-  正当散文）。frontmatter 是最小 `key: value` 解析（非全 YAML）；global repo-agnostic 的「本仓名」标识需
-  promoter 把 `repo_name` 喂入（v1 仅 abs-path）。
+  正当散文）。frontmatter 是最小 `key: value` 解析（非全 YAML）。
 - [ ] **intent_queue durable 格式定稿**（与 [validate-store](research-loom/design/validate-store.md)「intent 队列是否持久」待解同）：
   v1 = repo state 区 per-run `*.jsonl`，read 不删 / land 后 clear（at-least-once）；最终格式 / 粒度待定。
 - [ ] **promoter LED watermark + create anchor 接 CAP**（Phase 4）：v1 LED 条目 = `{action, reason, evidence}`、
@@ -49,6 +42,3 @@
   在 Phase 5 补；改写要点：去掉 Hermes 进程内 fork / 直接写盘假设（我方 reflector 只发 intent、碰不到盘），
   接我方 compare-first 偏好序 + 单一来源 `format_spec`。设计已记「仿 `_SKILL_REVIEW_PROMPT`」于
   [reflector-subagent](research-loom/design/reflector-subagent.md)。
-- [x] **Wire doc checkers into CI.** Done: `.github/workflows/ci.yml` runs both checkers +
-  `--selftest` + `pytest -m "not live"` (tolerates empty collection until product tests land).
-  Test strategy & execution order in `docs/plans/roadmap.md`.


### PR DESCRIPTION
Cleans up `docs/TODO.md`:

- Removes 3 completed `[x]` items: S5 (MNG call-capture measurement), S1 (plugin agent hooks frontmatter measurement), doc-checker wired into CI.
- Fixes the validate #416 item: `repo_name` fed into promoter → validate already landed in Phase 2 (#29), so that clause is removed; keeps the still-pending "referenced-file existence / broken symlink".

Pure docs, doc-links check passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
