### PR TITLE
phase4(cap): capture + trigger — dumb-pipe zero-copy + egress redaction + Stop counter gate

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -42,3 +42,8 @@
   在 Phase 5 补；改写要点：去掉 Hermes 进程内 fork / 直接写盘假设（我方 reflector 只发 intent、碰不到盘），
   接我方 compare-first 偏好序 + 单一来源 `format_spec`。设计已记「仿 `_SKILL_REVIEW_PROMPT`」于
   [reflector-subagent](research-loom/design/reflector-subagent.md)。
+- [ ] **CAP 孤儿会话计数 GC 接 Phase 6**：崩溃 session 的 `session-<id>` 计数器残留，走 `on_session_start`
+  惰性扫删——该文件在 Phase 6（MNG）建，CAP 出 `clear_session` 原语先备。见 [cap](research-loom/design/cap.md) 待解。
+- [ ] **CAP 触发裁决 → 真 spawn 接 Phase 5**：Phase 4 `on_stop`/`on_session_end` 只出「是否触发 + 窗口 N」、
+  `capture.materialize` 备好脱敏窗物化；detached 后台 spawn reflector 由 Phase 5 `hook/spawn.py` 接（触发→读取
+  race 的 transcript 上界也随 spawn 带，cap.md 待解）。

--- a/docs/plans/phase4-cap.md
+++ b/docs/plans/phase4-cap.md
@@ -1,0 +1,40 @@
+# Phase 4 — CAP 捕获 + 触发 实现计划
+
+> 工作艺术品。设计权威：[cap](../research-loom/design/cap.md)、落位 [architecture](../research-loom/design/architecture.md)、顺序 [roadmap](roadmap.md) §Phase 4。
+
+## 交付物
+
+CAP = 哑管 + egress 脱敏 + 触发，全程确定性、不调 LLM。复用 Phase 1 `counters` / `redact` / `atomic`。
+
+1. **`hook/capture.py`**（交什么）：触发那刻从宿主 transcript 取 tail-N exchange 窗 → 过 egress 红线（`redact`）→ 原子物化到 handoff 路径给 reflector 跨进程读。**零内容拷贝**（不触发不抄）、**绝不回写宿主 raw log**。
+2. **`hook/on_stop.py`**（何时触发·每轮）：`CLAUDE_CODE_CHILD_SESSION` 有值即早退（递归 guard，且不计数）→ `bump_session` → 满 `reflect_every_n` 则 `reset_session` 并出触发裁决，未满退出。每 Stop O(1)、**不扫 transcript**。
+3. **`hook/on_session_end.py`**（何时触发·收尾）：计数 > 0 即 flush 余量（窗口 N = 当前计数、非阈值），随后自删会话计数器。
+4. **`counters.clear_session`**（最小扩展）：SessionEnd 自删用，unlink 缺失即忽略。
+
+触发节奏 == 喂窗大小（同为 `reflect_every_n`）→ 计数器一物双用、零重叠。detached spawn 本身是 [reflector-subagent](../research-loom/design/reflector-subagent.md) 的载体、接 Phase 5 `spawn.py`；本 Phase 出**触发裁决 + 窗口 N**，spawn 据此调 `capture.materialize`。
+
+## ponytail 上限
+
+- **transcript 解析 = 宿主格式假设**：exchange 切分按「user 角色起新窗」、字段容错抽 role/text。真 Claude Code `.jsonl` schema + compaction 下 tail-N 是否取到原始轮次 = Phase 0 live spike（[cap](../research-loom/design/cap.md) 待解）。解析标 ceiling、按 fixture 测不变量、spike 定真格式。
+- **spawn 调用**：on_stop/on_session_end 出裁决，不直接 detached spawn（Phase 5 `spawn.py` 接）。
+
+## 单元（每单元 tests 先于 code）
+
+1. `counters.clear_session`（tests→code）：unlink、缺失幂等。
+2. `capture`（tests→code）：tmp transcript fixture → tail-N 取最近 N exchange；窗内 secret/PII 被 `redact`；`materialize` 原子写 handoff、**宿主 transcript 字节不变**；窗大小 == N（零重叠）。
+3. `on_stop`（tests→code）：每 Stop +1；满 N 触发并清零；未满不触发；`CLAUDE_CODE_CHILD_SESSION` 早退**不 +1**（递归 guard）；裁决不带 transcript 扫描。
+4. `on_session_end`（tests→code）：计数 > 0 → 触发、窗口 N == 计数；== 0 → 不触发；收尾后计数器文件已删。
+5. 集成：N-1 个 Stop 不触发、第 N 个触发清零、再跑到 SessionEnd flush 尾巴。
+
+## 不变量 / 红队
+
+- **egress 脱敏在物化窗、非宿主 raw log**：materialize 后断言宿主 transcript 字节不变、handoff 窗已脱敏。
+- **递归 guard**：child session 的 Stop 不计数、不触发 → reflector 自身 Stop 不致无限反思。
+- **不扫 transcript 计数**：on_stop 只读改写小 int 计数器（O(1)），触发那刻才读一次 transcript 取窗。
+- 不安全 session-id → `counters` 抛（已 Phase 1 测，CAP 复用同守卫）。
+
+## 范围外 / TODO
+
+- **`on_session_start` 孤儿计数 GC** → Phase 6（该文件在 MNG 建）；cap.md 已记「留待解」。
+- **触发→读取 race**（满 N 到 detached 真读间又来 1~2 轮，tail-N 漏最老）→ v0 容忍，精确化随 spawn 带 transcript 上界（Phase 5）。
+- **episode 边界信号**（task-done / token 预算）→ 未定，v0 攒够 N 近似（[ref](../research-loom/design/ref.md) 共享待解）。

--- a/src/autoharness/config.py
+++ b/src/autoharness/config.py
@@ -16,3 +16,5 @@ CAPACITY = {layer.GLOBAL: 20, layer.PROJECT: 50}  # ponytail: 占位，待标定
 _LIB = Path(__file__).parent / "lib"
 REDACTION_RULES = _LIB / "redaction_rules.toml"  # secret/PII 规则集，CAP egress + LED 单一来源
 FORMAT_SPEC = _LIB / "format_spec.md"            # #416 authoring + lint 单一来源
+
+CHILD_SESSION_ENV = "CLAUDE_CODE_CHILD_SESSION"  # 平台递归 guard 信号：spawn 置、CAP hook 读（单一来源）

--- a/src/autoharness/hook/capture.py
+++ b/src/autoharness/hook/capture.py
@@ -1,0 +1,75 @@
+"""CAP 交接物：触发那刻从宿主 transcript 取脱敏 tail-N 窗，物化给 reflector 跨进程读。
+
+cap.md：CAP 零内容拷贝——不触发不抄；触发时取最近 N exchange（N == reflect_every_n，与触发
+节奏同数、零重叠），过 egress 红线（redact），原子物化到 handoff 路径。**绝不回写宿主 raw
+log**（它不是我们的）。脱敏发生在「物化给下游那一刻」、非某份入口存储副本。
+
+ponytail: exchange 切分 = 宿主格式假设（user 角色起新窗、字段容错抽 role/text）。真 Claude
+Code .jsonl schema + compaction 下 tail-N 是否取到原始轮次 = Phase 0 live spike（cap.md 待解）；
+解析按 fixture 测不变量，spike 定真格式后再校准。
+"""
+import json
+from pathlib import Path
+
+from autoharness.lib import atomic, redact
+
+
+def _records(transcript_path):
+    p = Path(transcript_path)
+    if not p.exists():
+        return []
+    records = []
+    for line in p.read_text().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            records.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return records
+
+
+def _role(rec):
+    return str(rec.get("role") or rec.get("type") or "")
+
+
+def _text(rec):
+    msg = rec.get("message") if isinstance(rec.get("message"), dict) else rec
+    content = msg.get("content", msg.get("text", ""))
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for block in content:
+            if isinstance(block, dict):
+                parts.append(str(block.get("text") or block.get("content") or ""))
+            else:
+                parts.append(str(block))
+        return " ".join(p for p in parts if p)
+    return str(content)
+
+
+def _exchanges(records):
+    exchanges, current = [], []
+    for rec in records:
+        if _role(rec).startswith("user") and current:
+            exchanges.append(current)
+            current = []
+        current.append(rec)
+    if current:
+        exchanges.append(current)
+    return exchanges
+
+
+def window(transcript_path, n, *, rules_path=None):
+    if n <= 0:
+        return ""
+    tail = _exchanges(_records(transcript_path))[-n:]
+    lines = [f"{_role(rec)}: {_text(rec)}" for ex in tail for rec in ex]
+    return redact.redact("\n".join(lines), rules_path)
+
+
+def materialize(transcript_path, n, dest, *, rules_path=None):
+    atomic.write_text(dest, window(transcript_path, n, rules_path=rules_path))
+    return dest

--- a/src/autoharness/hook/on_session_end.py
+++ b/src/autoharness/hook/on_session_end.py
@@ -1,0 +1,28 @@
+"""CAP 触发（收尾）：SessionEnd flush 余量 + 自删会话计数器。
+
+cap.md：不满阈值的尾巴若不 flush 会永远丢；故会话结束时计数 > 0 即反思余量，**当前计数值
+正好告诉 REF 喂几个**（窗口 N == 计数、非阈值）。随后会话计数器随 session 生死自删。
+递归 guard 同 on_stop：reflector 子会话的 SessionEnd 不 flush。
+
+ponytail: 崩溃 session 的孤儿计数器走 SessionStart 惰性 GC（Phase 6 该文件建时落，cap.md 待解）。
+"""
+import os
+
+from autoharness import config
+from autoharness.lib import counters
+
+
+def on_session_end(event, *, root=None):
+    if os.environ.get(config.CHILD_SESSION_ENV):
+        return {"triggered": False, "reason": "recursion_guard"}
+    session_id = event.get("session_id")
+    if not session_id:
+        return {"triggered": False, "reason": "no_session"}
+    try:
+        count = counters.session_count(session_id, root)
+    except ValueError:
+        return {"triggered": False, "reason": "bad_session"}
+    counters.clear_session(session_id, root)
+    if count > 0:
+        return {"triggered": True, "session_id": session_id, "window_n": count, "count": count}
+    return {"triggered": False, "session_id": session_id, "count": 0}

--- a/src/autoharness/hook/on_stop.py
+++ b/src/autoharness/hook/on_stop.py
@@ -1,0 +1,31 @@
+"""CAP 触发（每轮）：Stop hook + 递归 guard + 计数闸，全确定性、不调 LLM。
+
+cap.md：唯一拿到「每次响应结束」的信号是 Stop。但 Stop=每轮、episode=跨多轮任务，故不每
+Stop 都 spawn——读小 int +1（O(1)、不扫 transcript），满 reflect_every_n 才出触发裁决并清零。
+detached spawn 本身接 Phase 5 spawn.py；本步只出「是否触发 + 窗口 N」，spawn 据此调
+capture.materialize（窗口 N == 阈值，与触发节奏同数、零重叠）。
+
+递归 guard：reflector 子会话（CHILD_SESSION_ENV 有值）的 Stop 不得再触发反思、且不计数，
+否则无限自反思。坏/缺 session-id → 不触发（fail-safe，不崩宿主 hook）。
+"""
+import os
+
+from autoharness import config
+from autoharness.lib import counters
+
+
+def on_stop(event, *, root=None, n=None):
+    if os.environ.get(config.CHILD_SESSION_ENV):
+        return {"triggered": False, "reason": "recursion_guard"}
+    session_id = event.get("session_id")
+    if not session_id:
+        return {"triggered": False, "reason": "no_session"}
+    n = n or config.REFLECT_EVERY_N
+    try:
+        count = counters.bump_session(session_id, root)
+    except ValueError:
+        return {"triggered": False, "reason": "bad_session"}
+    if count >= n:
+        counters.reset_session(session_id, root)
+        return {"triggered": True, "session_id": session_id, "window_n": n, "count": count}
+    return {"triggered": False, "session_id": session_id, "count": count, "n": n}

--- a/src/autoharness/lib/counters.py
+++ b/src/autoharness/lib/counters.py
@@ -50,3 +50,9 @@ def bump_session(session_id, root=None):
 
 def reset_session(session_id, root=None):
     atomic.write_text(_session_path(session_id, root), "0")
+
+
+def clear_session(session_id, root=None):
+    p = _session_path(session_id, root)
+    if p.exists():
+        p.unlink()

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -1,0 +1,54 @@
+import json
+
+from autoharness.hook import capture
+
+
+def _write_transcript(p, exchanges):
+    lines = []
+    for user_text, assistant_text in exchanges:
+        lines.append(json.dumps({"type": "user", "message": {"role": "user", "content": user_text}}))
+        lines.append(json.dumps({"type": "assistant",
+                                 "message": {"role": "assistant", "content": assistant_text}}))
+    p.write_text("\n".join(lines) + "\n")
+
+
+def _users(window_text):
+    return [ln for ln in window_text.splitlines() if ln.startswith("user:")]
+
+
+def test_window_takes_tail_n_exchanges(tmp_path):
+    t = tmp_path / "transcript.jsonl"
+    _write_transcript(t, [(f"q{i}", f"a{i}") for i in range(5)])
+    w = capture.window(t, 2)
+    assert "q3" in w and "q4" in w
+    assert "q0" not in w and "q2" not in w
+
+
+def test_window_size_equals_n_zero_overlap(tmp_path):
+    t = tmp_path / "transcript.jsonl"
+    _write_transcript(t, [(f"q{i}", f"a{i}") for i in range(10)])
+    assert len(_users(capture.window(t, 3))) == 3
+
+
+def test_window_redacts_egress(tmp_path):
+    t = tmp_path / "transcript.jsonl"
+    _write_transcript(t, [("my key is AKIAIOSFODNN7EXAMPLE", "mail me jane.doe@example.com")])
+    w = capture.window(t, 1)
+    assert "AKIAIOSFODNN7EXAMPLE" not in w
+    assert "jane.doe@example.com" not in w
+    assert "[REDACTED:" in w
+
+
+def test_materialize_atomic_no_source_mutation(tmp_path):
+    t = tmp_path / "transcript.jsonl"
+    _write_transcript(t, [("secret AKIAIOSFODNN7EXAMPLE here", "ok")])
+    before = t.read_bytes()
+    dest = tmp_path / "state" / "window.md"
+    out = capture.materialize(t, 1, dest)
+    assert out == dest and dest.exists()
+    assert t.read_bytes() == before  # 宿主 raw log 字节不变
+    assert "AKIAIOSFODNN7EXAMPLE" not in dest.read_text()  # 物化窗已脱敏
+
+
+def test_window_missing_transcript_empty(tmp_path):
+    assert capture.window(tmp_path / "nope.jsonl", 5) == ""

--- a/tests/test_counters.py
+++ b/tests/test_counters.py
@@ -24,6 +24,14 @@ def test_session_counter_bump_and_reset(tmp_path):
     assert counters.session_count(sid, tmp_path) == 0
 
 
+def test_clear_session_deletes_and_idempotent(tmp_path):
+    counters.bump_session("abc-123", tmp_path)
+    assert counters._session_path("abc-123", tmp_path).exists()
+    counters.clear_session("abc-123", tmp_path)
+    assert counters.session_count("abc-123", tmp_path) == 0
+    counters.clear_session("abc-123", tmp_path)  # 缺失幂等、不抛
+
+
 def test_unknown_layer_rejected(tmp_path):
     with pytest.raises(ValueError):
         counters.bump_request("staging", tmp_path)

--- a/tests/test_on_session_end.py
+++ b/tests/test_on_session_end.py
@@ -1,0 +1,40 @@
+from autoharness import config
+from autoharness.hook import on_session_end
+from autoharness.lib import counters
+
+EV = {"session_id": "sess-1"}
+
+
+def _unguard(monkeypatch):
+    monkeypatch.delenv(config.CHILD_SESSION_ENV, raising=False)
+
+
+def test_flush_remaining_window_equals_count(monkeypatch, tmp_path):
+    _unguard(monkeypatch)
+    counters.bump_session("sess-1", tmp_path)
+    counters.bump_session("sess-1", tmp_path)
+    counters.bump_session("sess-1", tmp_path)  # 不满阈值的尾巴 = 3
+    v = on_session_end.on_session_end(EV, root=tmp_path)
+    assert v["triggered"] and v["window_n"] == 3  # 当前计数告诉 REF 喂几个
+
+
+def test_self_deletes_counter(monkeypatch, tmp_path):
+    _unguard(monkeypatch)
+    counters.bump_session("sess-1", tmp_path)
+    p = counters._session_path("sess-1", tmp_path)
+    assert p.exists()
+    on_session_end.on_session_end(EV, root=tmp_path)
+    assert not p.exists()  # 收尾自删
+
+
+def test_no_flush_when_zero(monkeypatch, tmp_path):
+    _unguard(monkeypatch)
+    v = on_session_end.on_session_end(EV, root=tmp_path)
+    assert not v["triggered"]
+
+
+def test_recursion_guard_no_flush(monkeypatch, tmp_path):
+    monkeypatch.setenv(config.CHILD_SESSION_ENV, "reflector-xyz")
+    counters.bump_session("sess-1", tmp_path)
+    v = on_session_end.on_session_end(EV, root=tmp_path)
+    assert not v["triggered"]

--- a/tests/test_on_stop.py
+++ b/tests/test_on_stop.py
@@ -1,0 +1,38 @@
+from autoharness import config
+from autoharness.hook import on_stop
+from autoharness.lib import counters
+
+EV = {"session_id": "sess-1"}
+
+
+def _unguard(monkeypatch):
+    monkeypatch.delenv(config.CHILD_SESSION_ENV, raising=False)
+
+
+def test_each_stop_increments_no_trigger(monkeypatch, tmp_path):
+    _unguard(monkeypatch)
+    for expected in (1, 2, 3):
+        v = on_stop.on_stop(EV, root=tmp_path, n=10)
+        assert not v["triggered"] and v["count"] == expected
+
+
+def test_triggers_and_resets_at_n(monkeypatch, tmp_path):
+    _unguard(monkeypatch)
+    on_stop.on_stop(EV, root=tmp_path, n=3)
+    on_stop.on_stop(EV, root=tmp_path, n=3)
+    v = on_stop.on_stop(EV, root=tmp_path, n=3)
+    assert v["triggered"] and v["window_n"] == 3
+    assert counters.session_count("sess-1", tmp_path) == 0  # 触发即清零
+    assert on_stop.on_stop(EV, root=tmp_path, n=3)["count"] == 1  # 下一轮从 1 起
+
+
+def test_recursion_guard_early_exit_no_count(monkeypatch, tmp_path):
+    monkeypatch.setenv(config.CHILD_SESSION_ENV, "reflector-xyz")
+    v = on_stop.on_stop(EV, root=tmp_path, n=3)
+    assert not v["triggered"]
+    assert counters.session_count("sess-1", tmp_path) == 0  # child Stop 不计数
+
+
+def test_missing_session_safe(monkeypatch, tmp_path):
+    _unguard(monkeypatch)
+    assert not on_stop.on_stop({}, root=tmp_path, n=3)["triggered"]


### PR DESCRIPTION
## Phase 4 — CAP capture + trigger

Design authority [cap](docs/research-loom/design/cap.md) · plan [phase4-cap](docs/plans/phase4-cap.md) · sequence [roadmap §Phase 4](docs/plans/roadmap.md)

CAP = dumb pipe + egress redaction + trigger, **deterministic throughout, never calls the LLM**, reusing Phase 1 `counters`/`redact`/`atomic`.

### Deliverable
- **`hook/capture.py`** (what gets handed off): at the trigger moment, take a tail-N exchange window from the host transcript → run it through egress red-line redaction → atomically materialize the handoff for the reflector to read across processes. **Zero content copying** (nothing copied if not triggered), **never writes back to the host raw log**.
- **`hook/on_stop.py`** (every turn): `CLAUDE_CODE_CHILD_SESSION` recursion guard (a child Stop neither counts nor triggers) → `bump_session` → on reaching `reflect_every_n`, reset to zero and emit the trigger verdict. O(1) per Stop, **never scans the transcript**.
- **`hook/on_session_end.py`** (cleanup): if count > 0, flush the remainder (window N == current count) + self-delete the session counter.
- **`counters.clear_session`**: used by the SessionEnd self-delete, idempotent when missing.

Trigger cadence == feed-window size (same `reflect_every_n`) → the counter serves double duty with zero overlap.

### Seams (this Phase only emits the trigger verdict + window N)
- detached background spawn of the reflector → Phase 5 `hook/spawn.py`.
- GC of orphaned session counts → Phase 6 `on_session_start` (the `clear_session` primitive is prepared ahead).
- `config.CHILD_SESSION_ENV` single source (set by spawn / read by hook).

### ponytail ceiling
Splitting the transcript into exchanges = an assumption about the host format (a new window starts at user, fields are extracted with role/text tolerance); fidelity of tail-N under the real `.jsonl` schema + compaction = a Phase 0 live spike. Invariants are tested against fixtures; the spike pins down the real format. Recorded in [TODO](docs/TODO.md) / [cap open questions](docs/research-loom/design/cap.md).

### Tests
14 new tests assert invariants: tail-N windowing / window size == N with zero overlap / **egress redaction acts on the materialized window, the host raw log is byte-for-byte unchanged** / +1 per Stop, reaching N triggers and resets / recursion guard does not count / SessionEnd flushes the remainder and self-deletes / `clear_session` idempotent.

Full `pytest -m "not live"` **97 passed** · ruff clean · doc-links / research-loom checkers green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
