### PR TITLE
docs(readme): architecture diagram ASCII→Mermaid

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,20 +29,23 @@ symbols are judged by **invocation rate**, not elapsed time.
 
 A learning pipeline runs beside the host and keeps all of itself off the host's recall path.
 
-```
-              recall (native, untouched)
-   ┌──────────────────────────────────────────────┐
-   │            host agent session                 │
-   └───────────────────────┬──────────────────────┘
-                           │  hooks observe each turn
-                           ▼
-   CAP capture ──▶ REF reflect ──▶ promoter · validate & store
-   dumb pipe       compare-first    lint in memory; atomic write on pass
-   redact at exit  proposes intent              │ pass only
-                                                ▼
-   MNG archives weakest ──▶  .claude/skills (live symbols)
-                                                │
-                                                └──▶ LED ledger (per-symbol sidecar)
+```mermaid
+flowchart TB
+    host["host agent session"]
+    cap["CAP capture<br/>dumb pipe · redact at exit"]
+    ref["REF reflect<br/>compare-first · proposes intent"]
+    prom["promoter · validate &amp; store<br/>lint in memory · atomic write on pass"]
+    skills[(".claude/skills<br/>live symbols")]
+    mng["MNG · archives weakest"]
+    led[("LED ledger<br/>per-symbol sidecar")]
+
+    host -->|hooks observe each turn| cap
+    cap --> ref
+    ref --> prom
+    prom -->|pass only| skills
+    mng --> skills
+    skills --> led
+    skills -->|recall: native, untouched| host
 ```
 
 - **Author and validator are separate.** REF only proposes an intent; it has no write tools. The


### PR DESCRIPTION
Route the readme change committed directly on local `main` (`1f9b617 update reademe`) through a PR instead.

**Background**: that commit was based on a stale README (before #29–#32 were merged), and its diff replaces the ASCII diagram after the *old* table with Mermaid. A direct cherry-pick conflicts — `origin/main`'s README has been rewritten, with the architecture diagram moved into the "How it works" section and the copy updated.

**This PR's approach**: rather than mechanically applying the old content's Mermaid (which would contradict the new prose), convert the **current** `origin/main` ASCII architecture diagram into an equivalent Mermaid, carrying the node/edge semantics over from the current diagram verbatim: host session →(hooks observe)→ CAP →REF→ promoter →(pass only)→ `.claude/skills`; MNG archival is weakest, LED sidecar, native recall back to host. The rest of the new prose is left untouched.

Checks: all 7 nodes declared, every edge reference resolvable, `check_doc_links docs` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
