### PR TITLE
docs: hang the LED node below to dodge GitHub's Mermaid control overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ flowchart LR
     host -->|hooks| cap --> ref -->|intent| prom -->|pass| skills
     skills -->|recall| host
     mng --> skills
-    skills -.-> led
+    prom -.append.-> led
 ```
 
 - **Author and validator are separate.** REF only proposes an intent; it has no write tools. The


### PR DESCRIPTION
## What
After #35 merged, we found that in the LR layout LED ended up at the far right — exactly where GitHub's copy/zoom controls sit in the top-right corner when it renders the Mermaid diagram. Changed LED to hang down from promoter (`prom -.append.-> led`), leaving only `.claude/skills` at the far right to clear the controls' position.

## Why
The promoter is the ledger's sole writer, so hanging LED below it is also semantically more accurate. The rest of the diagram's relationships are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
