### PR TITLE
phase6(mng): invocation-rate lifecycle + probation + capacity competition

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -39,15 +39,18 @@
   clear 之间）补处理会重 append 同一 LED 条目（SKILL.md 写幂等、LED 非幂等）。逐 intent watermark 待队列粒度定。
 - [ ] **promoter 跨进程单写者锁**（与 sidecar/ledger 并发锁、mng 待解合一）：v1 单进程同步即「串行」，
   两 run 并发同改一 skill 的锁粒度（last-writer）待定。
-- [ ] **delete 归档 = 移进 `.archive`（Phase 2 落）**；最终「交 MNG 归档」的退役编排（保留期 / GC）属 Phase 6 lifecycle。
+- [x] **delete 归档 + MNG 退役编排（Phase 6 落）**：`lib/lifecycle.py`（率 + 缓刑 + 容量竞争判定）+
+  `hook/on_session_start.py`（惰性现算 → 逐个 `skill_store.archive`）+ `skill_store.restore`（可逆复活）落地。
+  设计「只归档不删除」故无 `.archive` 保留期 / GC——archived 永久可 restore，非待 GC。
 - [ ] **Phase 5 reflector 正文借 Hermes skill-create review-fork prompt**：`agents/reflector.md` 的 compare-first
   review + authoring 正文以 Hermes 后台 fork 的创建/复盘 prompt 为蓝本（`_spawn_background_review` 的
   `_SKILL_REVIEW_PROMPT` / `build_learn_prompt`，见 [hermes 源卡](research-loom/sources/github/nousresearch-hermes-agent.md)），
   在 Phase 5 补；改写要点：去掉 Hermes 进程内 fork / 直接写盘假设（我方 reflector 只发 intent、碰不到盘），
   接我方 compare-first 偏好序 + 单一来源 `format_spec`。设计已记「仿 `_SKILL_REVIEW_PROMPT`」于
   [reflector-subagent](research-loom/design/reflector-subagent.md)。
-- [ ] **CAP 孤儿会话计数 GC 接 Phase 6**：崩溃 session 的 `session-<id>` 计数器残留，走 `on_session_start`
-  惰性扫删——该文件在 Phase 6（MNG）建，CAP 出 `clear_session` 原语先备。见 [cap](research-loom/design/cap.md) 待解。
+- [ ] **CAP 孤儿会话计数 GC（policy 仍缺存活信号）**：`on_session_start` 已建（Phase 6），但「哪个
+  `session-<id>` 是孤儿」需会话存活信号——朴素扫删会误删并发会话的活计数，故 GC 暂不接进 `on_session_start`。
+  `clear_session` 原语已备（Phase 4），等存活信号再落。见 [cap](research-loom/design/cap.md) 待解。
 - [ ] **CAP 触发裁决 → 真 spawn 接 Phase 5**：Phase 4 `on_stop`/`on_session_end` 只出「是否触发 + 窗口 N」、
   `capture.materialize` 备好脱敏窗物化；detached 后台 spawn reflector 由 Phase 5 `hook/spawn.py` 接（触发→读取
   race 的 transcript 上界也随 spawn 带，cap.md 待解）。

--- a/docs/plans/phase6-mng.md
+++ b/docs/plans/phase6-mng.md
@@ -1,0 +1,49 @@
+# plan — Phase 6：MNG 生命周期
+
+> 工作艺术品（非设计文档）。装配自 [roadmap](roadmap.md) Phase 6 + [mng](../research-loom/design/mng.md)。
+> 每单元 docs→tests→code、tests 先于 code。
+
+## 范围
+
+确定性生命周期：调用率定生死、缓刑护新、容量竞争、惰性 `SessionStart` 现算、archived 移目录出召回（可逆）。复用 Phase 1 的 `counters`（层请求分母）/ `sidecar`（calls 分子 + anchor）/ `skill_store`（archive）。
+
+1. `lib/lifecycle.py` —— 纯确定性判定：成员→(分母=层请求−锚, 率=calls/分母)→缓刑/毕业/毕业即审/容量竞争→产「待归档名单」。不碰盘。
+2. `lib/skill_store.py` —— 补 `restore`（archive 的逆：`.archive/<name>` 移回 live），落「移回复活（可逆）」。
+3. `hook/on_skill_call.py` —— `PreToolUse(Skill)` 分子 +1：解析被调符号→层定位→**仅自产符号** bump_calls（零侵入：绝不给原生 / 用户 skill 写 sidecar）+ 递归 guard。
+4. `hook/on_session_start.py` —— 惰性重算：每层收成员 sidecar + 层请求数 + config 阈值/上限 → lifecycle 判定 → 逐个 archive。判定只读累积水位（跨 session / 跨 repo 同结论）。
+
+**不在本 Phase（留 TODO）**：CAP 孤儿会话计数 GC——`clear_session` 原语已备（Phase 4），但「哪个 session 是孤儿」需会话存活信号，朴素扫删会误删并发会话的活计数；缺信号前不实现（concurrency-unsafe）。绝对底线规则（毕业审外的硬底线 Y）、滚动窗口率、global 并发写锁、覆盖盲区——mng.md 待解，留后。
+
+## 单元
+
+### U1 docs
+mng.md 已完整钉死率/缓刑/容量/触发/可逆——无新设计事实，**不改**（守 docs 简洁律）。仅 U5 扫 index/TODO。
+
+### U2 tests+code — `lifecycle.evaluate`（纯函数）+ `skill_store.restore`
+- `evaluate(members, request_count, *, maturity, capacity)` → 待归档名单：
+  - 分母 = `max(0, request_count − anchor)`；分母 < maturity → 缓刑（live、不淘汰、不占上限）。
+  - 毕业（分母 ≥ maturity）：calls==0 → 毕业即审当场归档。
+  - 成熟存活池（calls>0）超 capacity → 按 (率升序, name) 归档最低者至回上限内。
+- test 断言**不变量**：缓刑符号永不入归档；calls==0 毕业即归档；成熟超容按率序淘汰最低、不淘汰高率；分母随 request_count 增长（关系非绝对值）；tie 用 name 稳定。
+- `restore`：`.archive/<name>` 原子移回 `skills/<name>`，sidecar 随迁；archive→restore 往返后 live 存在、归档区空（可逆）。
+
+### U3 tests+code — `on_skill_call`（分子埋点）
+- 自产符号被调 → 其 sidecar calls +1（层由 find 解析）。
+- **非自产 / 原生符号被调 → 不写 sidecar**（零侵入红线，最关键红队点）。
+- 递归 guard（CHILD_SESSION_ENV 有值早退、不计）；坏/缺符号名 fail-safe 不崩。
+
+### U4 tests+code — `on_session_start`（惰性重算，集成 `tmp_path`）
+- 多符号跨缓刑/成熟/零调，跑 handler → 该归档的移出 live 树、该留的留；archived 不在 live、可 restore 复活。
+- 判定只读 sidecar + 层请求计数器累积水位 → 任意 root 的 SessionStart 同结论（喂同账两次得同果）。
+- 复用 promoter 的 `.tmp` sweep？on_session_start 只管 MNG；`.tmp` 孤儿已由 promoter.drain sweep，不重复。
+
+### U5 verify + sweep
+- `pytest -m "not live"` 全绿；doc checkers 绿。
+- TODO：勾「delete 归档退役编排属 Phase 6」相关、补「孤儿会话 GC 仍缺存活信号」延期说明。扫 design/index.md（mng 条目已在，确认无需改）。
+
+## 测试映射（roadmap 不变量）
+- 「调用率 + 缓刑 + 容量竞争」→ U2 unit。
+- 「archived 移目录出召回、可逆」→ U2 restore + U4 集成。
+- 「判定读累积水位、任意 repo 同结论」→ U4。
+- 「零侵入：不碰原生 / 用户 skill」→ U3 红队（非自产不写 sidecar）。
+- 「MNG handler 挂单一 dispatcher、零 daemon」→ 结构（handler 是纯函数、SessionStart 现算，无常驻）；dispatch 路由 Phase 7。

--- a/src/autoharness/hook/on_session_start.py
+++ b/src/autoharness/hook/on_session_start.py
@@ -1,0 +1,41 @@
+"""MNG 惰性重算：SessionStart 那刻对累积账现算 → 归档失活符号，跑在本会话召回前。
+
+mng.md：非常驻宿主无后台 sweep，故淘汰骑 SessionStart——读 sidecar（calls 分子 + anchor）+
+层请求计数器（分母）累积水位、过 lifecycle 判定、把待归档名单逐个移出 live 树（archived 靠
+移目录出召回、可逆）。判定只读累积量（不读本 session 看到什么）→ 任意 repo 的 SessionStart
+同一结论。每会话一次、不节流。只管自产符号（原生 / 用户 skill 在池外，守零侵入）。
+
+ponytail: 孤儿会话计数 GC（崩溃 session 残留）需会话存活信号才能安全扫（朴素扫会误删并发
+会话的活计数），缺信号前不做——clear_session 原语已备（Phase 4），policy 留 cap.md/mng.md 待解。
+"""
+from autoharness import config
+from autoharness.lib import counters, layer, lifecycle, sidecar, skill_store
+
+
+def _members(lyr, root):
+    skills = layer.skills_dir(lyr, root)
+    if not skills.exists():
+        return []
+    members = []
+    for path in skills.glob(f"*/{skill_store.SKILL_FILE}"):
+        name = path.parent.name
+        if not sidecar.is_agent_created(lyr, name, root):
+            continue
+        s = sidecar.read(lyr, name, root)
+        members.append({"name": name, "calls": s.get("calls", 0), "anchor": s.get("anchor", 0)})
+    return members
+
+
+def on_session_start(event=None, *, roots=None):
+    roots = roots or {}
+    archived = {}
+    for lyr in layer.LAYERS:
+        root = roots.get(lyr)
+        names = lifecycle.evaluate(
+            _members(lyr, root), counters.request_count(lyr, root),
+            maturity=config.MATURITY_THRESHOLD[lyr], capacity=config.CAPACITY[lyr],
+        )
+        for name in names:
+            skill_store.archive(lyr, name, root)
+        archived[lyr] = names
+    return {"archived": archived}

--- a/src/autoharness/hook/on_skill_call.py
+++ b/src/autoharness/hook/on_skill_call.py
@@ -1,0 +1,42 @@
+"""MNG 分子埋点：`PreToolUse(Skill)` 那刻给被调符号 sidecar calls +1，纯观察不拦截。
+
+mng.md：率分子 = 被调次数，存被调符号 sidecar、层无关（身份决定落哪层）。**零侵入红线——
+只给自产符号计数**，绝不给原生 / 用户 skill 写 sidecar（碰它们即违反不碰宿主作品）。递归
+guard 同 CAP：reflector 子会话不计。坏 / 未知 / 同名歧义符号 fail-safe 不崩宿主 hook。
+
+ponytail: event 里符号身份的确切 key = Phase 0 spike（mng.md 待解）；现按几个候选字段容错抽。
+"""
+import os
+
+from autoharness import config
+from autoharness.lib import sidecar, skill_store
+
+
+def _skill_name(event):
+    nested = event.get("tool_input") if isinstance(event.get("tool_input"), dict) else {}
+    for src in (event, nested):
+        for key in ("skill_name", "skill", "name"):
+            v = src.get(key)
+            if isinstance(v, str) and v.strip():
+                return v
+    return None
+
+
+def on_skill_call(event, *, roots=None):
+    if os.environ.get(config.CHILD_SESSION_ENV):
+        return {"counted": False, "reason": "recursion_guard"}
+    roots = roots or {}
+    name = _skill_name(event)
+    if not name:
+        return {"counted": False, "reason": "no_skill"}
+    try:
+        lyr = skill_store.find(name, roots)
+    except ValueError:
+        return {"counted": False, "reason": "bad_or_ambiguous"}
+    if lyr is None:
+        return {"counted": False, "reason": "not_managed"}
+    root = roots.get(lyr)
+    if not sidecar.is_agent_created(lyr, name, root):
+        return {"counted": False, "reason": "not_agent_created"}
+    calls = sidecar.bump_calls(lyr, name, root)
+    return {"counted": True, "level": lyr, "name": name, "calls": calls}

--- a/src/autoharness/lib/lifecycle.py
+++ b/src/autoharness/lib/lifecycle.py
@@ -1,0 +1,31 @@
+"""MNG 判定：纯确定性，调用率 + 缓刑 + 容量竞争 → 产「待归档名单」。不碰盘。
+
+mng.md：成存依据是**调用率**（被调次数 / 创建以来层请求数）非墙钟。缓刑护新（分母未过成熟阈值
+= live 但不淘汰、不占上限）；毕业即审（满样本仍 calls==0 当场归档）；成熟存活池超上限按率升序
+归档最低者。判定只读累积水位（sidecar calls + anchor、层请求计数），故任意 repo 的 SessionStart
+同一结论。on_session_start 拿本名单逐个 skill_store.archive。
+
+ponytail: 绝对底线规则（毕业审外的硬底线 Y）、滚动窗口率留后（mng.md 待解）。
+"""
+
+
+def _rate(calls, denom):
+    return calls / denom if denom else 0.0
+
+
+def evaluate(members, request_count, *, maturity, capacity):
+    archive = set()
+    survivors = []
+    for m in members:
+        denom = max(0, request_count - m.get("anchor", 0))
+        if denom < maturity:
+            continue  # 缓刑：live、不淘汰、不占上限
+        calls = m.get("calls", 0)
+        if calls == 0:
+            archive.add(m["name"])  # 毕业即审：给够机会仍零调
+            continue
+        survivors.append((_rate(calls, denom), m["name"]))
+    if len(survivors) > capacity:
+        survivors.sort(key=lambda rn: rn)  # 率升序，率同按 name 稳定
+        archive.update(name for _, name in survivors[: len(survivors) - capacity])
+    return sorted(archive)

--- a/src/autoharness/lib/skill_store.py
+++ b/src/autoharness/lib/skill_store.py
@@ -65,6 +65,18 @@ def archive(lyr, name, root=None):
     return dest
 
 
+def restore(lyr, name, root=None):
+    src = layer.archive_dir(lyr, root) / name
+    if not src.exists():
+        return None
+    dest = layer.symbol_dir(lyr, name, root)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    if dest.exists():
+        shutil.rmtree(dest)
+    os.replace(src, dest)
+    return dest
+
+
 def sweep_orphans(lyr, root=None):
     skills = layer.skills_dir(lyr, root)
     if not skills.exists():

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -1,0 +1,56 @@
+from autoharness.lib import lifecycle
+
+
+def _m(name, calls, anchor=0):
+    return {"name": name, "calls": calls, "anchor": anchor}
+
+
+def test_probation_never_archived():
+    # denom = 5 - 0 = 5 < maturity 10 → probation, even with zero calls
+    out = lifecycle.evaluate([_m("new", 0)], request_count=5, maturity=10, capacity=1)
+    assert out == []
+
+
+def test_graduation_audit_zero_calls_archived():
+    # denom = 20 ≥ maturity 10, calls 0 → archived on graduation
+    out = lifecycle.evaluate([_m("idle", 0)], request_count=20, maturity=10, capacity=5)
+    assert out == ["idle"]
+
+
+def test_capacity_competition_archives_lowest_rate():
+    members = [_m("hi", 80), _m("mid", 40), _m("lo", 5)]  # denom 100 each, rates .8/.4/.05
+    out = lifecycle.evaluate(members, request_count=100, maturity=10, capacity=2)
+    assert out == ["lo"]  # only the weakest of the mature pool, kept down to capacity
+
+
+def test_high_rate_kept_under_capacity():
+    members = [_m("a", 50), _m("b", 90)]
+    out = lifecycle.evaluate(members, request_count=100, maturity=10, capacity=5)
+    assert out == []  # under capacity → nobody archived
+
+
+def test_denominator_grows_with_requests():
+    # same symbol: probation at low request count, auditable once denom passes maturity
+    m = [_m("x", 0, anchor=0)]
+    assert lifecycle.evaluate(m, request_count=9, maturity=10, capacity=5) == []      # denom 9 < 10
+    assert lifecycle.evaluate(m, request_count=10, maturity=10, capacity=5) == ["x"]  # denom 10 ≥ 10
+
+
+def test_anchor_offsets_denominator():
+    # created late (anchor 95): denom = 100 - 95 = 5 < maturity → still probation
+    out = lifecycle.evaluate([_m("late", 0, anchor=95)], request_count=100, maturity=10, capacity=1)
+    assert out == []
+
+
+def test_capacity_tiebreak_by_name_deterministic():
+    # equal rates, capacity forces one out → lexicographically-first name archived
+    members = [_m("b", 10), _m("a", 10), _m("c", 10)]  # all rate .1
+    out = lifecycle.evaluate(members, request_count=100, maturity=10, capacity=2)
+    assert out == ["a"]
+
+
+def test_probation_does_not_count_toward_capacity():
+    # one mature survivor + two probation; capacity 1 not breached by probation members
+    members = [_m("mature", 50, anchor=0), _m("p1", 0, anchor=95), _m("p2", 0, anchor=96)]
+    out = lifecycle.evaluate(members, request_count=100, maturity=10, capacity=1)
+    assert out == []  # probation excluded from the mature pool, no capacity pressure

--- a/tests/test_on_session_start.py
+++ b/tests/test_on_session_start.py
@@ -1,0 +1,80 @@
+from autoharness import config
+from autoharness.hook import on_session_start
+from autoharness.lib import layer, sidecar, skill_store
+
+
+def _roots(base):
+    return {"global": base / "g", "project": base / "p"}
+
+
+def _seed(roots, name, calls, anchor=0, lvl="project"):
+    root = roots[lvl]
+    skill_store.write_body(lvl, name, f"---\nname: {name}\ndescription: d\n---\nb", root)
+    s = sidecar.create(lvl, name, anchor, root)
+    s["calls"] = calls
+    sidecar.write(lvl, name, s, root)
+
+
+def _set_requests(roots, lvl, n):
+    p = layer.state_dir(lvl, roots[lvl]) / "requests"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(str(n))
+
+
+def _small_knobs(monkeypatch, cap_project=5):
+    monkeypatch.setattr(config, "MATURITY_THRESHOLD", {"global": 10, "project": 10})
+    monkeypatch.setattr(config, "CAPACITY", {"global": 5, "project": cap_project})
+
+
+def test_archives_idle_and_overflow_keeps_strong_and_probation(tmp_path, monkeypatch):
+    _small_knobs(monkeypatch, cap_project=1)
+    roots = _roots(tmp_path)
+    _set_requests(roots, "project", 100)
+    _seed(roots, "idle", calls=0)             # mature, zero calls → graduation audit
+    _seed(roots, "weak", calls=5)             # rate .05, loses capacity race
+    _seed(roots, "strong", calls=80)          # rate .8, top of pool → kept
+    _seed(roots, "baby", calls=1, anchor=95)  # denom 5 < 10 → probation → survives
+
+    out = on_session_start.on_session_start(roots=roots)
+    assert set(out["archived"]["project"]) == {"idle", "weak"}
+    assert set(out["archived"]) == {"global", "project"}  # both layers processed
+    for gone in ("idle", "weak"):
+        assert not skill_store.exists("project", gone, roots["project"])
+    assert skill_store.exists("project", "strong", roots["project"])
+    assert skill_store.exists("project", "baby", roots["project"])
+    skill_store.restore("project", "weak", roots["project"])  # reversible
+    assert skill_store.exists("project", "weak", roots["project"])
+
+
+def test_native_skill_never_archived(tmp_path, monkeypatch):
+    _small_knobs(monkeypatch)
+    roots = _roots(tmp_path)
+    _set_requests(roots, "project", 100)
+    # native: no sidecar, zero usage, mature window — must stay (not a member)
+    skill_store.write_body("project", "native",
+                           "---\nname: native\ndescription: d\n---\nb", roots["project"])
+    out = on_session_start.on_session_start(roots=roots)
+    assert "native" not in out["archived"]["project"]
+    assert skill_store.exists("project", "native", roots["project"])
+
+
+def test_verdict_reads_accumulated_state_same_across_repos(tmp_path, monkeypatch):
+    _small_knobs(monkeypatch)
+    # two repos seeded identically → identical verdict (reads water level, not session)
+    def run(sub):
+        roots = _roots(tmp_path / sub)
+        _set_requests(roots, "project", 100)
+        _seed(roots, "idle", calls=0)
+        _seed(roots, "used", calls=50)
+        return on_session_start.on_session_start(roots=roots)["archived"]["project"]
+
+    assert run("a") == run("b") == ["idle"]
+
+
+def test_second_run_is_noop_after_archival(tmp_path, monkeypatch):
+    _small_knobs(monkeypatch)
+    roots = _roots(tmp_path)
+    _set_requests(roots, "project", 100)
+    _seed(roots, "idle", calls=0)
+    assert on_session_start.on_session_start(roots=roots)["archived"]["project"] == ["idle"]
+    assert on_session_start.on_session_start(roots=roots)["archived"]["project"] == []

--- a/tests/test_on_skill_call.py
+++ b/tests/test_on_skill_call.py
@@ -1,0 +1,64 @@
+import pytest
+
+from autoharness import config
+from autoharness.hook import on_skill_call
+from autoharness.lib import sidecar, skill_store
+
+
+@pytest.fixture(autouse=True)
+def _unguard(monkeypatch):
+    monkeypatch.delenv(config.CHILD_SESSION_ENV, raising=False)  # ambient may set it
+
+
+def _roots(tmp_path):
+    return {"global": tmp_path / "g", "project": tmp_path / "p"}
+
+
+def _seed_agent_skill(roots, name="foo"):
+    root = roots["project"]
+    skill_store.write_body("project", name, "b", root)
+    sidecar.create("project", name, anchor=0, root=root)
+    return root
+
+
+def test_agent_created_call_bumps_numerator(tmp_path):
+    roots = _roots(tmp_path)
+    root = _seed_agent_skill(roots)
+    r = on_skill_call.on_skill_call({"skill_name": "foo"}, roots=roots)
+    assert r["counted"] and r["level"] == "project"
+    assert sidecar.read("project", "foo", root)["calls"] == 1
+
+
+def test_nested_tool_input_name(tmp_path):
+    roots = _roots(tmp_path)
+    _seed_agent_skill(roots)
+    r = on_skill_call.on_skill_call({"tool_input": {"name": "foo"}}, roots=roots)
+    assert r["counted"]
+
+
+def test_native_or_user_skill_never_touched(tmp_path):
+    # present in tree but NOT agent-created → zero-intrusion: no sidecar write at all
+    roots = _roots(tmp_path)
+    root = roots["project"]
+    skill_store.write_body("project", "native", "b", root)
+    r = on_skill_call.on_skill_call({"skill_name": "native"}, roots=roots)
+    assert not r["counted"] and r["reason"] == "not_agent_created"
+    assert sidecar.read("project", "native", root) == {}  # untouched host artifact
+
+
+def test_unknown_symbol_failsafe(tmp_path):
+    r = on_skill_call.on_skill_call({"skill_name": "ghost"}, roots=_roots(tmp_path))
+    assert not r["counted"]
+
+
+def test_missing_name_failsafe(tmp_path):
+    assert not on_skill_call.on_skill_call({}, roots=_roots(tmp_path))["counted"]
+
+
+def test_recursion_guard_does_not_count(tmp_path, monkeypatch):
+    monkeypatch.setenv(config.CHILD_SESSION_ENV, "1")
+    roots = _roots(tmp_path)
+    root = _seed_agent_skill(roots)
+    r = on_skill_call.on_skill_call({"skill_name": "foo"}, roots=roots)
+    assert not r["counted"] and r["reason"] == "recursion_guard"
+    assert sidecar.read("project", "foo", root)["calls"] == 0  # reflector's own calls excluded

--- a/tests/test_skill_store.py
+++ b/tests/test_skill_store.py
@@ -39,6 +39,19 @@ def test_remove(tmp_path):
     assert not skill_store.exists("project", "foo", tmp_path)
 
 
+def test_archive_restore_roundtrip_preserves_sidecar(tmp_path):
+    from autoharness.lib import sidecar
+    skill_store.write_body("project", "foo", "real", tmp_path)
+    sidecar.create("project", "foo", anchor=3, root=tmp_path)
+    skill_store.archive("project", "foo", tmp_path)
+    assert not skill_store.exists("project", "foo", tmp_path)         # out of live tree
+    assert (layer.archive_dir("project", tmp_path) / "foo").exists()  # parked in archive
+    skill_store.restore("project", "foo", tmp_path)
+    assert skill_store.read_body("project", "foo", tmp_path) == "real"    # reversible
+    assert sidecar.read("project", "foo", tmp_path)["anchor"] == 3        # sidecar rode along
+    assert not (layer.archive_dir("project", tmp_path) / "foo").exists()  # archive slot cleared
+
+
 def test_sweep_orphans_removes_tmp_keeps_live(tmp_path):
     sdir = layer.symbol_dir("project", "foo", tmp_path)
     sdir.mkdir(parents=True)


### PR DESCRIPTION
## Phase 6 — MNG lifecycle

Deterministic, daemon-free curation of the self-produced skill layer, recomputed lazily at `SessionStart`. Survival is judged by **invocation rate**, not wall-clock — so ephemeral hosts never punish a symbol that simply had no turn to be used.

### Delivered
- **`lib/lifecycle.py`** — pure verdict. `denominator = layer requests − creation anchor`, `rate = calls / denominator`. **Probation** (`denominator < maturity`) stays live but is never archived and never counts toward capacity; **graduation audit** archives a matured symbol with zero calls; the mature survivor pool **over capacity** sheds lowest-rate first (name-stable tie-break).
- **`hook/on_skill_call.py`** — `PreToolUse(Skill)` numerator +1 on the called symbol's sidecar. **Zero-intrusion red line: only self-produced symbols are counted — never writes a sidecar into a native/user skill.** Recursion guard + fail-safe on bad/unknown/ambiguous symbol.
- **`hook/on_session_start.py`** — lazy recompute reading **accumulated watermark** (sidecar + per-layer request counters), so any repo's `SessionStart` reaches the same verdict; archives losers by moving dirs out of the live tree.
- **`skill_store.restore`** — inverse of `archive` (reversible reactivation).

`archived` = directory moved out of the live tree → native recall can't see it; reversible via `restore`.

### Tests (135 passed)
Invariants, not hardcoded values: probation never archived · graduation audit on zero-call maturity · capacity sheds lowest rate, keeps highest · denominator grows with request count · anchor offsets denominator · **native/user skills never touched** (red-team) · cross-repo determinism (same accumulated state → same verdict) · archive↔restore round-trip preserves sidecar.

### Deferred (TODO / mng.md open questions)
Orphan session-counter GC needs a session-liveness signal (naive sweep would delete a concurrent session's live counter); absolute-floor rule, rolling-window rate, and the global cross-process write lock stay open.

Local gate green: ruff · doc_links(+selftest) · research_loom(+selftest) · `pytest -m "not live"`.

> Note: independent of #37 (Phase 5) — touches different files (`lifecycle`/`on_skill_call`/`on_session_start`/`skill_store`/`config` untouched here). Branched off latest main.