### PR TITLE
phase7(plugin): live-host fixes — reflector MCP tool name, permission bypass, prompt

### DIFF
--- a/agents/reflector.md
+++ b/agents/reflector.md
@@ -1,7 +1,7 @@
 ---
 name: reflector
 description: Distill a finished episode into one aligned skill change. Compare-first; proposes intent only, never writes to disk.
-tools: Read, Grep, Glob, stage_skill
+tools: Read, Grep, Glob, mcp__plugin_autoharness_stage_skill__stage_skill
 model: haiku
 ---
 
@@ -29,9 +29,11 @@ Drafting a full skill first, then checking for overlap, produces wrong-shaped sk
 
 Prefer **patch / merge over create**. Create only when no existing skill — in either layer — is the right home.
 
-## Emitting the intent (`stage_skill`)
+## Emitting the intent (call the `stage_skill` tool)
 
-Stage exactly one intent for the change (or none). Fields:
+**You act by calling the `stage_skill` tool — not by writing text.** Do not output the SKILL.md, the action, or the fields as prose in your reply; a textual description creates nothing. The *only* thing that records a change is an actual invocation of the `stage_skill` tool. If you decide a change is warranted, your response must contain a tool call to `stage_skill`. After it returns, briefly confirm what you staged.
+
+Stage exactly one intent for the change (or none). Tool arguments:
 
 - `action`: `create` | `update` | `patch` | `delete`. Action follows from existence — you rarely need `update`; reach for `patch` to amend, `create` for genuinely new.
 - `create` / `update` carry the **full** `SKILL.md` body (satisfying the format spec). `patch` carries `old_string` → `new_string` (the `old_string` must match the live body uniquely). `delete` carries no body.

--- a/src/autoharness/hook/spawn.py
+++ b/src/autoharness/hook/spawn.py
@@ -44,7 +44,10 @@ def build_bundle(window, index, spec):
 
 
 def build_command(*, agent, claude_bin):
-    return [claude_bin, "-p", "--agent", agent]
+    # 反思是无人值守后台作业——没有人来批准工具调用，故跳过权限提示。安全边界由 agent 的
+    # tools 白名单（Read/Grep/Glob/stage_skill）+ 顶层 PreToolUse 写 backstop 兜，非靠提示。
+    # （live e2e：reflector 真调 stage_skill 被权限门挡下、只能"narrate"，加此 flag 才落地。）
+    return [claude_bin, "-p", "--agent", agent, "--dangerously-skip-permissions"]
 
 
 def child_env(run_id, root, *, base_env=None):

--- a/tests/test_lifecycle_e2e.py
+++ b/tests/test_lifecycle_e2e.py
@@ -1,0 +1,96 @@
+"""Full skill-lifecycle sandbox: birth → use → compete → archive → restore, driven through
+the real dispatch + spawn + promoter + lifecycle. Only the reflector model is a canned stub
+(fake_spawn stages one intent); everything else is the production path on an isolated tmp dir.
+
+This is the deterministic counterpart to the live host runbook (experiments/E7_plugin_e2e):
+it monitors every lifecycle transition on disk. The live run only adds "real Claude Code
+hooks/MCP/recall actually fire".
+"""
+import json
+
+import pytest
+
+from autoharness import config
+from autoharness.hook import capture, dispatch, spawn
+from autoharness.lib import counters, intent_queue, layer, ledger, sidecar, skill_store
+
+LEARNED = "---\nname: learned\ndescription: Does a specific repeatable thing.\n---\n# Learned\nSteps.\n"
+WEAK = "---\nname: weak\ndescription: Rarely useful side note.\n---\n# Weak\nx.\n"
+
+
+@pytest.fixture(autouse=True)
+def _small_isolated(monkeypatch):
+    monkeypatch.delenv(config.CHILD_SESSION_ENV, raising=False)
+    monkeypatch.setattr(config, "REFLECT_EVERY_N", 2)
+    monkeypatch.setattr(config, "MATURITY_THRESHOLD", {layer.GLOBAL: 2, layer.PROJECT: 2})
+    monkeypatch.setattr(config, "CAPACITY", {layer.GLOBAL: 5, layer.PROJECT: 1})
+
+
+def _roots(tmp_path):
+    return {layer.GLOBAL: tmp_path / "g", layer.PROJECT: tmp_path / "p"}
+
+
+def _transcript(tmp_path):
+    p = tmp_path / "transcript.jsonl"
+    lines = []
+    for i in range(4):
+        lines.append(json.dumps({"type": "user", "message": {"role": "user", "content": f"q{i}"}}))
+        lines.append(json.dumps({"type": "assistant", "message": {"role": "assistant", "content": f"a{i}"}}))
+    p.write_text("\n".join(lines) + "\n")
+    return p
+
+
+def test_full_skill_lifecycle_through_dispatch(tmp_path, capsys):
+    roots = _roots(tmp_path)
+    proot = roots[layer.PROJECT]
+    transcript = _transcript(tmp_path)
+    stop = {"hook_event_name": "Stop", "session_id": "s1", "transcript_path": str(transcript)}
+
+    def land_learned(event, result, rts):  # stands in for the spawned reflector
+        def fake_spawn(argv, env, bundle):
+            intent_queue.append(env[config.RUN_ID_ENV],
+                                {"action": "create", "name": "learned", "level": "project",
+                                 "body": LEARNED, "reason": "captured repeat", "evidence": "slice"},
+                                rts[layer.PROJECT])
+        spawn.run(capture.window(event["transcript_path"], result["window_n"]),
+                  dispatch._run_id(result), roots=rts, spawn_fn=fake_spawn)
+
+    # BEAT 1 — birth: drive Stops until the cadence triggers reflection
+    dispatch.dispatch(stop, roots=roots, reflect=land_learned)            # Stop 1: count<N, no trigger
+    assert skill_store.read_body("project", "learned", proot) is None
+    dispatch.dispatch(stop, roots=roots, reflect=land_learned)            # Stop 2: trigger → land
+    assert skill_store.read_body("project", "learned", proot) is not None
+    assert sidecar.is_agent_created("project", "learned", proot)
+    assert ledger.read("project", "learned", proot)[0]["action"] == "create"
+    assert counters.request_count(layer.PROJECT, proot) == 2              # denominator grew per Stop
+    print(f"[birth]  learned landed · denominator={counters.request_count(layer.PROJECT, proot)}")
+
+    # BEAT 2 — use: PreToolUse(Skill) bumps the numerator
+    for _ in range(2):
+        dispatch.dispatch({"hook_event_name": "PreToolUse", "tool_name": "Skill",
+                           "tool_input": {"name": "learned"}}, roots=roots)
+    assert sidecar.read("project", "learned", proot)["calls"] == 2
+    print(f"[use]    learned calls={sidecar.read('project', 'learned', proot)['calls']}")
+
+    # BEAT 3 — compete: a weak unused peer; MNG recompute (SessionStart) archives the loser.
+    skill_store.write_body("project", "weak", WEAK, proot)
+    sidecar.create("project", "weak", anchor=0, root=proot)              # mature (denom 2), zero calls
+    req = counters.request_count(layer.PROJECT, proot)
+    mat = config.MATURITY_THRESHOLD[layer.PROJECT]
+    for name in ("learned", "weak"):                                    # monitor MNG numerator/denominator
+        sc = sidecar.read("project", name, proot)
+        num, den = sc["calls"], req - sc["anchor"]
+        print(f"[mng]    {name}: numerator(calls)={num} denominator(reqs)={den} "
+              f"rate={num / den:.2f} mature={den >= mat}")
+    out = dispatch.dispatch({"hook_event_name": "SessionStart"}, roots=roots)
+    archived = out["result"]["archived"]["project"]
+    assert "weak" in archived and "learned" not in archived            # lowest rate sheds, adhered-to kept
+    assert not skill_store.exists("project", "weak", proot)             # moved out of live tree
+    assert (layer.archive_dir("project", proot) / "weak").exists()
+    assert skill_store.exists("project", "learned", proot)
+    print(f"[archive] capacity={config.CAPACITY[layer.PROJECT]} → archived={archived} · learned survives")
+
+    # BEAT 4 — restore: archival is reversible
+    skill_store.restore("project", "weak", proot)
+    assert skill_store.exists("project", "weak", proot)
+    print("[restore] weak reactivated")

--- a/tests/test_reflector_agent.py
+++ b/tests/test_reflector_agent.py
@@ -13,8 +13,12 @@ def test_reflector_frontmatter_present():
 def test_reflector_tools_are_least_privilege():
     fm = validate._frontmatter(AGENT.read_text())
     tools = fm["tools"]
-    for allowed in ("Read", "Grep", "Glob", "stage_skill"):
+    for allowed in ("Read", "Grep", "Glob"):
         assert allowed in tools
+    # Plugin MCP tools are named mcp__plugin_<plugin>_<server>__<tool> — a bare "stage_skill"
+    # (or even mcp__stage_skill__stage_skill) is silently dropped, leaving the reflector with
+    # no write face at all. The live e2e caught exactly this.
+    assert "mcp__plugin_autoharness_stage_skill__stage_skill" in tools
     for forbidden in ("Write", "Edit", "Bash"):
         assert forbidden not in tools  # author≠validator: no path to live skill tree
 

--- a/tests/test_spawn.py
+++ b/tests/test_spawn.py
@@ -57,6 +57,8 @@ def test_build_command_carries_agent_and_print():
     assert cmd[0] == "claude"
     assert "--agent" in cmd and "autoharness:reflector" in cmd
     assert "-p" in cmd
+    # autonomous spawn: no human to approve tool calls → must skip permission prompts
+    assert "--dangerously-skip-permissions" in cmd
 
 
 def test_child_env_sets_guard_and_coords_without_polluting():


### PR DESCRIPTION
Follow-up to #40 (merged). I installed the packaged plugin into a **real Claude Code host** (isolated sandbox: throwaway `HOME`+`CLAUDE_CONFIG_DIR`, verified real `~/.claude` untouched) and ran the **full lifecycle end-to-end**. It surfaced three bugs that only exist at the live host boundary — none catchable by unit tests, all now fixed:

| # | Bug | Fix |
|---|---|---|
| 1 | Plugin MCP tools are named `mcp__plugin_<plugin>_<server>__<tool>`. The agent allowlist had bare `stage_skill` → silently dropped → **reflector had no write face**. | `agents/reflector.md`: `mcp__plugin_autoharness_stage_skill__stage_skill` |
| 2 | An autonomous background reflector has no human to approve tool calls → the `stage_skill` call was permission-gated, so the reflector could only *narrate*. | `spawn.build_command`: `--dangerously-skip-permissions` (bounded by the tools allowlist + write backstop) |
| 3 | haiku authored a perfect SKILL.md but described staging instead of invoking the tool. | `agents/reflector.md`: imperative "call the tool, don't write text" |

### Live result (real installed plugin, sandbox)
```
Stop → MNG denominator +1 (both layers, on disk)
trigger → 3-piece bundle (redacted window + skill index + format_spec) → real reflector spawned
reflector → compare-first reasoning → authored SKILL.md → CALLED stage_skill
promoter drain → git-commit-scope-tags landed + created_by:agent + LED(reason,evidence)
PreToolUse(Skill) → numerator calls=3
SessionStart → rate-based archive: rate 1.50 survives, weak peer rate 0.00 archived
restore → reversible
real ~/.claude/skills touched? False
```

### Also added
`tests/test_lifecycle_e2e.py` — deterministic full-lifecycle through `dispatch` (birth→use→compete→archive→restore) with MNG numerator/denominator monitored, fake reflector, minimum config. **177 passed, 1 deselected (live).**