### PR TITLE
docs: rewrite README around the self-learning pitch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,28 @@
 <h1 align="center">autoharness</h1>
 
-<p align="center"><strong>A per-symbol maintenance optimizer for an agent's skill layer — it learns skills from real runs and lets them earn their keep by being adhered to in use, not by an offline eval score.</strong></p>
-
 <p align="center">
-  <img src="https://img.shields.io/badge/status-built%20%26%20e2e--validated-brightgreen.svg" alt="status" />
-  <img src="https://img.shields.io/badge/lifecycle-zero--daemon-blue.svg" alt="zero daemon" />
-  <img src="https://img.shields.io/badge/form-Claude%20Code%20plugin-brightgreen.svg" alt="plugin" />
+  <img src="https://img.shields.io/badge/release-v0.1.0-brightgreen.svg" alt="release" />
+  <img src="https://img.shields.io/badge/python-3.11%2B-blue.svg" alt="python" />
+  <img src="https://img.shields.io/badge/platform-Linux%20%7C%20macOS-lightgrey.svg" alt="platform" />
   <img src="https://img.shields.io/badge/license-MIT-yellow.svg" alt="license MIT" />
 </p>
 
-Agents accumulate skills, and the skill layer needs maintaining. Most approaches either grow it
-unbounded or age skills out on a wall-clock timer behind a resident daemon — punishing a skill for
-sitting unused even when the host never had a chance to use it.
+**autoharness is a self-learning skill layer for Claude Code.** It learns skills from your real
+sessions, merges same-scenario ones instead of stacking near-duplicates, updates them in use, and
+prunes the unused — isolated beside the agent, touching only the skills it wrote itself.
 
-autoharness watches a host agent's own sessions, distills each episode into a skill, and lands it
-into the native skill directory (`.claude/skills`) where the host recalls it normally. Skills that
-keep getting invoked survive; ones that go unused or get contradicted are archived. It runs
-**beside** the host — never touching the skill load or recall path, only observing through hooks and
-writing to disk. There is **no daemon**: the lifecycle recomputes lazily at session start, and
-symbols are judged by **invocation rate**, not elapsed time.
+Same model, different harness — 42% → 78% on CORE-Bench ([HAL](https://arxiv.org/abs/2510.11977)).
+The harness does much of the work (swyx's **Big Model vs Big Harness**), yet it's still rebuilt by
+hand every model generation. autoharness bets one slice of it — the skill layer — can maintain
+itself, learning from real work instead of an offline eval.
 
-> [!NOTE]
-> **Built and validated end-to-end.** The full pipeline (Phases 1–7) is implemented, and the
-> packaged plugin has been run on a real Claude Code host in an isolated sandbox — install →
-> capture → reflect → land → invoke → archive → restore, with skills judged by invocation rate.
+| | |
+|---|---|
+| **Learns from real work** | Each episode is distilled into a skill from the session you were already having — no separate data-collection or replay loop. |
+| **Groups, doesn't just pile up** | A new episode doesn't always add a skill — the reflector compares it against what's there and folds same-scenario skills into one, so the layer consolidates by category instead of accreting near-duplicates. |
+| **Validated in use, not on a benchmark** | A skill survives by being adhered to in later turns (invocation rate), not a held-out score. No oracle on the active path, and no tokens spent on a dedicated eval. |
+| **Only its own skills** | Touches only the skills it generated through this plugin — everything else, whether you wrote it or installed it, is left completely alone. |
+| **Evidence kept for later** | Every create/update logs its scenario and decision to a per-skill ledger — the raw material to build a benchmark from real usage if you ever want one. |
 
 ## Install
 
@@ -35,86 +34,64 @@ dependencies); its hooks and MCP server won't fire without it.
 /plugin install autoharness@autoharness
 ```
 
-Restart Claude Code, then verify it's live:
+Restart Claude Code, then check it's live:
 
 ```
 /plugin    # autoharness@autoharness — enabled
 /mcp       # stage_skill — connected
 ```
 
-That's it — zero config. autoharness now watches your sessions; at an episode boundary it reflects
-in the background and lands learned skills into `.claude/skills/`, recalled by the host's own
-name-and-description mechanism (autoharness never touches the recall path). Cadence and lifecycle
-thresholds are tunable via `AUTOHARNESS_*` environment variables.
+Zero config. It now watches your sessions and lands learned skills into `.claude/skills/` in the
+background. Cadence and lifecycle thresholds are tunable via `AUTOHARNESS_*` environment variables.
+
+### Uninstall
+
+```
+claude plugin uninstall autoharness@autoharness     # stops the hooks + MCP server
+claude plugin marketplace remove autoharness        # optional — also drops the install source
+```
+
+Uninstalling only stops it from running — the skills it landed and its own state live **outside** the
+plugin and stay on disk. To clear those too, delete its state dir (`~/.claude/autoharness/` global,
+`<repo>/.claude/autoharness/` per project) and the self-authored skills under `.claude/skills/` (each
+carries a `self-authored` ledger marker, so they're easy to tell from yours). Your own skills are
+never touched.
 
 ## How it works
 
-A learning pipeline runs beside the host and keeps all of itself off the host's recall path.
+A learning pipeline runs beside the host and stays off its recall path — symbols are plain native
+skills, recalled by the host's own name-and-description mechanism as if a human had written them.
 
 <p align="center"><img src="docs/assets/pipeline.svg" alt="autoharness pipeline: host → CAP → REF → promoter → .claude/skills → host, with MNG and LED beside" width="760" /></p>
 
 <sub>Diagram source: [`docs/assets/pipeline.mmd`](docs/assets/pipeline.mmd) — re-render to `pipeline.svg` after editing.</sub>
 
-- **Author and validator are separate.** REF only proposes an intent; it has no write tools. The
-  promoter is the sole writer and gates every intent through a deterministic linter.
-- **Nothing lands until it passes.** The promoter shapes and lints the intent in memory and only
-  then does an atomic rename into the live skill directory — no half-written skills on disk.
-- **The host is never modified.** Symbols are plain native skills; the host recalls them by its own
-  name-and-description mechanism, exactly as if a human had written them.
-
 | Component | Role |
 |---|---|
 | **CAP** · capture | Hook-driven dumb pipe: grabs each turn (user input, agent output, tool I/O), redacts at egress, points back at the host log instead of copying it. |
-| **REF** · reflect | At an episode boundary, compare-first: reads the existing skill index, decides add / merge / patch / delete, and emits an intent (body or delta, plus reason and evidence). Proposes only. |
-| **promoter** · validate·store | The only writer. Shapes the intent in memory, runs a deterministic linter (safety, structure, ledger, completeness, self-authored-only), and on pass does an atomic rename into the live skill directory. |
-| **MNG** · lifecycle | Deterministic and daemon-free. Ranks symbols by invocation rate per layer, shields new ones during probation, archives the weakest when a mature pool is over capacity. Archives, never deletes. |
-| **LED** · ledger | Per-symbol append-only sidecar recording why each symbol was born or changed, with evidence and a reflection watermark. Kept out of the skill body so recall stays clean. |
+| **REF** · reflect | At an episode boundary, reads the existing skill index and decides add / merge / patch / delete — emits an intent (body or delta, plus reason and evidence). Proposes only; no write tools. |
+| **promoter** · validate·store | The only writer. Lints the intent in memory (safety, structure, ledger, completeness, self-authored-only) and on pass does an atomic rename into the live skill directory. |
+| **MNG** · lifecycle | Daemon-free. Ranks symbols by invocation rate per layer, shields new ones during probation, archives the weakest when a mature pool is over capacity. Archives, never deletes. |
+| **LED** · ledger | Per-symbol append-only sidecar: why each symbol was born or changed, with evidence and a reflection watermark. Kept out of the skill body so recall stays clean. |
 
-## Design
+## How it compares
 
-### Adherence over eval
+A self-learning skill layer can be validated against a held-out benchmark, or against its own use.
+autoharness takes the second — cheaper, and it works on a live host doing open-ended work where no
+benchmark exists.
 
-A skill earns survival by being followed and working across later interactions, not by a one-shot
-offline score. There is no oracle and no held-out benchmark on the active path; the signal is the
-host's own usage.
+| | Grow unbounded | Offline-gated self-edit<br/>([Self-Harness](https://arxiv.org/abs/2606.09498)) | Timer + daemon<br/>([hermes-agent](https://github.com/NousResearch/hermes-agent)) | autoharness |
+| --- | --- | --- | --- | --- |
+| Bounds the skill layer | No | Yes | Yes | Yes |
+| Validation signal | None | Held-out benchmark score | Wall-clock inactivity | Adherence in use |
+| Needs a benchmark / oracle | No | Yes | No | No |
+| Needs a resident daemon | No | No | Yes | No |
 
-### Zero-daemon lifecycle
+## Acknowledgements
 
-No background process. The lifecycle recomputes at session start and ranks symbols by invocation
-rate (calls since creation, per layer) rather than wall-clock age — so on ephemeral hosts a symbol
-is never punished for never having had the chance to be used.
-
-### Pure-additive, zero-intrusion
-
-Enhancement happens only through a single plugin hook dispatcher plus writes to the skill
-directory. Hooks observe and lazily curate; they never alter the host's skill registration or
-recall path.
-
-### Validate-before-any-write
-
-Precise and safe concerns (safety scan, commit, name collisions) are deterministic; judgment calls
-(duplication, correctness, value) are the LLM's. The model only proposes — landing is the
-deterministic promoter's alone, and nothing reaches disk before it passes.
-
-### One plugin, data split by layer
-
-The final form is a single Claude Code plugin: one copy of the code, execution only from the hook
-layer, and only data and state split global versus repo.
-
-## Why not just let skills accumulate, or age them out on a timer?
-
-Unbounded growth degrades recall — the more near-duplicate descriptions compete, the worse the host
-picks. Timer-based archival assumes a resident process and a host that runs continuously; on
-ephemeral, per-invocation hosts, elapsed time wrongly condemns symbols that simply had no turn to be
-used. autoharness keeps the layer bounded by adherence instead.
-
-| | Grow unbounded | Timer + daemon (e.g. [Hermes-Agent](https://github.com/NousResearch/Hermes-Agent)) | autoharness |
-| --- | --- | --- | --- |
-| Bounds the skill layer | No | Yes | Yes |
-| Needs a resident daemon | No | Yes | No |
-| Survival signal | None | Wall-clock inactivity | Invocation rate in use |
-| Fair on ephemeral hosts | n/a | No | Yes |
-| Author separated from validator | n/a | No | Yes |
+[NousResearch/hermes-agent](https://github.com/NousResearch/hermes-agent) — studying its
+auto-skill-creation and memory-consolidation design helped sharpen autoharness's adherence-based,
+daemon-free take.
 
 Built by Tigerless Labs.
 


### PR DESCRIPTION
Rewrites the README to lead with the pitch and cut repetition.

- **Pitch first.** One bold sentence saying what autoharness is (learn / group / update / prune; isolated; only its own skills), then the Big Model vs Big Harness motivation ([HAL](https://arxiv.org/abs/2510.11977)).
- **Feature table** replaces the prose Design section.
- **Uninstall** section added (uninstall is required; marketplace remove is optional; landed skills + state live outside the plugin).
- **Comparison table** trimmed to defensible rows — dropped the unverifiable `Touches only its own skills` row against hermes-agent.
- Removed an unsubstantiated end-to-end / sandbox claim.

No code changes.