### PR TITLE
docs: drop the offline-eval clause from the Big Harness paragraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,7 @@ the skills it wrote itself**.
 
 Same model, different harness — 42% → 78% on CORE-Bench ([HAL](https://arxiv.org/abs/2510.11977)).
 The harness does much of the work (swyx's **Big Model vs Big Harness**), yet it's still rebuilt by
-hand every model generation. autoharness bets one slice of it — the skill layer — can maintain
-itself, learning from real work instead of an offline eval.
+hand every model generation. autoharness bets one slice of it — the skill layer — can maintain itself.
 
 | | |
 |---|---|


### PR DESCRIPTION
Trims the second intro paragraph to end at "can maintain itself.", dropping `, learning from real work instead of an offline eval` — shorter, and avoids leading on a no-benchmark framing here. Lead paragraph (A, bolded) is unchanged.

This change was meant to ride along with #45 but didn't land on main; this PR carries just that 2-line trim.