### PR TITLE
fix: recursion guard misfired on every turn (wrong env var)

### DIFF
--- a/src/autoharness/config.py
+++ b/src/autoharness/config.py
@@ -32,7 +32,7 @@ _LIB = Path(__file__).parent / "lib"
 REDACTION_RULES = _LIB / "redaction_rules.toml"  # secret/PII rule set, single source for CAP egress + LED
 FORMAT_SPEC = _LIB / "format_spec.md"            # #416 single source for authoring + lint
 
-CHILD_SESSION_ENV = "CLAUDE_CODE_CHILD_SESSION"  # platform recursion-guard signal: set by spawn, read by CAP hook (single source)
+CHILD_SESSION_ENV = "AUTOHARNESS_CHILD_SESSION"  # recursion-guard signal: set ONLY by spawn, read by CAP hooks (single source). Must be autoharness-owned: the host sets CLAUDE_CODE_CHILD_SESSION on every hook subprocess, so reusing it would gate every top-level turn.
 
 REFLECTOR_AGENT = "autoharness:reflector"  # the --agent reference for spawn (plugin namespace, Phase 0 resolution pending live test)
 CLAUDE_BIN = "claude"                       # the child-session executable for spawn; PATH resolution, overridable in tests

--- a/tests/test_on_session_end.py
+++ b/tests/test_on_session_end.py
@@ -38,3 +38,10 @@ def test_recursion_guard_no_flush(monkeypatch, tmp_path):
     counters.bump_session("sess-1", tmp_path)
     v = on_session_end.on_session_end(EV, root=tmp_path)
     assert not v["triggered"]
+
+
+def test_platform_child_var_does_not_gate_flush(monkeypatch, tmp_path):
+    _unguard(monkeypatch)
+    monkeypatch.setenv("CLAUDE_CODE_CHILD_SESSION", "1")  # host sets this on every hook subprocess, not just reflectors
+    counters.bump_session("sess-1", tmp_path)
+    assert on_session_end.on_session_end(EV, root=tmp_path)["triggered"]

--- a/tests/test_on_skill_call.py
+++ b/tests/test_on_skill_call.py
@@ -62,3 +62,11 @@ def test_recursion_guard_does_not_count(tmp_path, monkeypatch):
     r = on_skill_call.on_skill_call({"skill_name": "foo"}, roots=roots)
     assert not r["counted"] and r["reason"] == "recursion_guard"
     assert sidecar.read("project", "foo", root)["calls"] == 0  # reflector's own calls excluded
+
+
+def test_platform_child_var_does_not_gate_counting(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAUDE_CODE_CHILD_SESSION", "1")  # host sets this on every hook subprocess, not just reflectors
+    roots = _roots(tmp_path)
+    root = _seed_agent_skill(roots)
+    r = on_skill_call.on_skill_call({"skill_name": "foo"}, roots=roots)
+    assert r["counted"] and sidecar.read("project", "foo", root)["calls"] == 1

--- a/tests/test_on_stop.py
+++ b/tests/test_on_stop.py
@@ -33,6 +33,12 @@ def test_recursion_guard_early_exit_no_count(monkeypatch, tmp_path):
     assert counters.session_count("sess-1", tmp_path) == 0  # child Stop does not count
 
 
+def test_platform_child_var_does_not_gate_counting(monkeypatch, tmp_path):
+    _unguard(monkeypatch)
+    monkeypatch.setenv("CLAUDE_CODE_CHILD_SESSION", "1")  # host sets this on every hook subprocess, not just reflectors
+    assert on_stop.on_stop(EV, root=tmp_path, n=10).get("count") == 1
+
+
 def test_missing_session_safe(monkeypatch, tmp_path):
     _unguard(monkeypatch)
     assert not on_stop.on_stop({}, root=tmp_path, n=3)["triggered"]


### PR DESCRIPTION
## Problem

The reflection recursion guard keyed on `CLAUDE_CODE_CHILD_SESSION`, on the premise it is *"set by Claude Code, only in child sessions."* It isn't — the host injects that var into **every** hook subprocess (alongside `CLAUDE_CODE_SESSION_ID`, `CLAUDECODE`, …). So the guard fired on every top-level turn:

- `on_stop`, `on_skill_call`, `on_session_end` all early-returned.
- Session counting, the MNG call **numerator**, and reflection **triggering** never advanced.
- Only the request **denominator** (bumped before the guard) moved — the loop looked alive while learning was fully off, in any real session.

Caught from on-disk state: `requests` advanced but no `session-<id>` file ever appeared; the var was present in a normal hook subprocess env yet absent from settings/shell/the claude parent's own environ.

## Why tests missed it

Both layers removed the exact trigger condition. `dev_skill`'s sandbox e2e `pop()`s `CLAUDE_CODE_CHILD_SESSION` (documented as a known quirk); unit `_unguard` `delenv`s it. The platform var that breaks production was deleted in every test — and never asserted to *not* gate counting.

## Fix

One source-of-truth change: `config.CHILD_SESSION_ENV` → `AUTOHARNESS_CHILD_SESSION`. `spawn` already sets it via the same constant; all three guards read via the same constant. The host's var is no longer referenced.

## Tests

3 regression tests (one per guard): with the **platform** var set and the **autoharness** var unset, counting/flush must proceed — RED before, GREEN after. Existing guard tests still assert the autoharness-owned var early-returns. Full suite: 180 passed. ruff clean. Host-style replay confirms 3 Stops count (was 0) while a reflector child still guards to 0.

## Follow-ups (not in this PR)

- `dev_skill` e2e should *keep* the platform var and assert top-level counting (it currently clears it).
- research-loom design docs (`cap.md`, `reflector-subagent.md`, on unmerged branches) carry the wrong "子会话才有" premise — correct when those land.
- Installed plugin (cache copy) needs an update/reinstall after merge for live sessions to pick this up.