### PR TITLE
chore: gitignore .X/ launch-post drafts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ build/
 .CLAUDE.md
 
 dev_skill/
+# launch-post drafts + diagrams (x-launch-post skill)
+.X/
 # dev-internal (lives on the dev branch, excluded from the public release)
 CLAUDE.md
 docs/research-loom/


### PR DESCRIPTION
Ignore `.X/` — local launch-post drafts + diagrams produced by the x-launch-post skill. Sibling to the already-ignored `dev_skill/`.