### PR TITLE
docs: bump README release badge to v0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <h1 align="center">autoharness</h1>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/release-v0.1.0-brightgreen.svg" alt="release" />
+  <img src="https://img.shields.io/badge/release-v0.2.0-brightgreen.svg" alt="release" />
   <img src="https://img.shields.io/badge/python-3.11%2B-blue.svg" alt="python" />
   <img src="https://img.shields.io/badge/platform-Linux%20%7C%20macOS-lightgrey.svg" alt="platform" />
   <img src="https://img.shields.io/badge/license-MIT-yellow.svg" alt="license MIT" />


### PR DESCRIPTION
Align the README release badge with plugin.json 0.2.0 / tag v0.2.0 (folder-skills, #49).