### PR TITLE
fix: remap project-layer root from linked worktree to main worktree root

### DIFF
--- a/src/autoharness/lib/layer.py
+++ b/src/autoharness/lib/layer.py
@@ -3,8 +3,17 @@
 The rest of the code is layer-agnostic and passes layer in as an argument. Unknown layers / unsafe
 symbol names are always rejected (fail-safe, deny-by-default), because this is the chokepoint that
 builds filesystem paths: privilege escalation / path traversal must be stopped here.
+
+The project layer's identity is the session cwd — except inside a linked git worktree, where it is
+remapped to the main worktree root, so counters / intents / skills from all worktrees of one repo
+land in one place and survive worktree removal. Only the linked-worktree case is remapped (git-dir
+differs from git-common-dir): plain repos, repo subdirectories, and non-git directories keep cwd
+verbatim, so a nested project can never be attributed to an enclosing repo. Any git failure falls
+back to cwd (fail-safe).
 """
 import re
+import subprocess
+from functools import cache
 from pathlib import Path
 
 GLOBAL = "global"
@@ -24,9 +33,29 @@ def _check_name(name):
         raise ValueError(f"unsafe symbol name: {name!r}")
 
 
+@cache
+def _main_worktree_root(cwd):
+    try:
+        proc = subprocess.run(
+            ["git", "rev-parse", "--git-dir", "--git-common-dir"],
+            cwd=cwd, capture_output=True, text=True, timeout=5,
+        )
+        lines = proc.stdout.splitlines()
+        if proc.returncode != 0 or len(lines) < 2:
+            return Path(cwd)
+        git_dir, common_dir = ((Path(cwd) / line).resolve() for line in lines[:2])
+        if git_dir != common_dir:
+            return common_dir.parent
+    except (OSError, subprocess.SubprocessError):
+        pass
+    return Path(cwd)
+
+
 def default_root(layer):
     _check_layer(layer)
-    return Path.home() / ".claude" if layer == GLOBAL else Path.cwd() / ".claude"
+    if layer == GLOBAL:
+        return Path.home() / ".claude"
+    return _main_worktree_root(str(Path.cwd())) / ".claude"
 
 
 def _root(layer, root):

--- a/tests/test_layer.py
+++ b/tests/test_layer.py
@@ -1,3 +1,5 @@
+import subprocess
+
 import pytest
 
 from autoharness.lib import layer
@@ -63,3 +65,85 @@ def test_subfile_gate_rejects(bad):
 
 def test_subfile_dirs_whitelist_is_the_four():
     assert set(layer.SUBFILE_DIRS) == {"scripts", "templates", "assets", "references"}
+
+
+# --- project root: linked-worktree remap ---
+
+def _git(cwd, *args):
+    subprocess.run(
+        ["git", "-c", "user.name=t", "-c", "user.email=t@t", *args],
+        cwd=cwd, check=True, capture_output=True,
+    )
+
+
+@pytest.fixture
+def main_repo(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    (repo / "f.txt").write_text("x")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-q", "-m", "init")
+    return repo
+
+
+@pytest.fixture
+def linked_worktree(main_repo):
+    wt = main_repo / ".claude" / "worktrees" / "br"
+    _git(main_repo, "worktree", "add", "-q", "-b", "br", str(wt))
+    return wt
+
+
+def _project_root_at(monkeypatch, cwd):
+    monkeypatch.chdir(cwd)
+    return layer.default_root(layer.PROJECT)
+
+
+def test_project_root_non_git_is_cwd(tmp_path, monkeypatch):
+    assert _project_root_at(monkeypatch, tmp_path) == tmp_path / ".claude"
+
+
+def test_project_root_main_repo_is_cwd(main_repo, monkeypatch):
+    assert _project_root_at(monkeypatch, main_repo) == main_repo / ".claude"
+
+
+def test_project_root_repo_subdir_stays_cwd_no_jump_to_repo_root(main_repo, monkeypatch):
+    sub = main_repo / "nested_project"
+    sub.mkdir()
+    assert _project_root_at(monkeypatch, sub) == sub / ".claude"
+
+
+def test_project_root_linked_worktree_maps_to_main_root(linked_worktree, main_repo, monkeypatch):
+    assert _project_root_at(monkeypatch, linked_worktree) == main_repo / ".claude"
+
+
+def test_project_root_worktree_and_main_resolve_same_path(linked_worktree, main_repo, monkeypatch):
+    from_wt = _project_root_at(monkeypatch, linked_worktree)
+    from_main = _project_root_at(monkeypatch, main_repo)
+    assert from_wt == from_main
+
+
+def test_project_root_worktree_subdir_maps_to_main_root(linked_worktree, main_repo, monkeypatch):
+    sub = linked_worktree / "src"
+    sub.mkdir()
+    assert _project_root_at(monkeypatch, sub) == main_repo / ".claude"
+
+
+def test_project_root_worktree_outside_repo_maps_to_main_root(main_repo, tmp_path, monkeypatch):
+    wt = tmp_path / "outside-wt"
+    _git(main_repo, "worktree", "add", "-q", "-b", "out", str(wt))
+    assert _project_root_at(monkeypatch, wt) == main_repo / ".claude"
+
+
+def test_project_root_git_failure_falls_back_to_cwd(linked_worktree, monkeypatch):
+    def boom(*args, **kwargs):
+        raise FileNotFoundError("git not installed")
+    monkeypatch.setattr(layer.subprocess, "run", boom)
+    layer._main_worktree_root.cache_clear()
+    assert _project_root_at(monkeypatch, linked_worktree) == linked_worktree / ".claude"
+
+
+def test_project_root_global_layer_unaffected(linked_worktree, monkeypatch):
+    monkeypatch.chdir(linked_worktree)
+    assert layer.default_root(layer.GLOBAL) == layer.default_root(layer.GLOBAL)
+    assert ".claude/worktrees" not in str(layer.default_root(layer.GLOBAL))


### PR DESCRIPTION
## Problem

All project-layer state (request counters, session windows, intents, handoff, skills) derives from `Path.cwd()/.claude`. Sessions running inside a linked git worktree (`.claude/worktrees/<branch>`) wrote state into the worktree's own `.claude/`:

- the MNG denominator (requests counter) fragmented between the main repo and each worktree;
- reflector/promoter-produced skills landed inside the worktree and were lost when it was removed.

## Fix

Single-chokepoint remap in `layer.default_root(PROJECT)`:

- `git rev-parse --git-dir --git-common-dir` equal → main worktree or plain directory: keep `Path.cwd()` (zero behavior change);
- different → linked worktree: map to the common-dir's parent (main worktree root);
- git missing / error / non-git directory → fall back to `Path.cwd()` (fail-safe).

Deliberately not "resolve the git root": a non-git subproject nested in an enclosing repo, or a session opened in a repo subdirectory, must keep cwd as its project identity.

Both reads and writes route through this one chokepoint (`dispatch._roots`), so the skill index, MNG scan, promoter output, and counters all converge on the main repo.

## Verification

- 84 lines of new unit tests in `tests/test_layer.py` (real git repos in tmp_path): non-git fallback, main-root unchanged, repo subdirectory unchanged, nested non-git subproject not escalated, linked worktree → main root, git failure fallback, worktree/main-root invariant. Full suite: 238 passed.
- End-to-end: fed a `Stop` event to dispatch from inside an existing linked worktree — the session counter and request counter landed in the main repo's `.claude/autoharness/`, nothing written in the worktree.
- One-time cleanup done locally: residual worktree request counts folded back into the main repo counter, stray worktree state dirs removed.