### PR TITLE
feat: raw byte-watermark capture; release v0.2.3

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autoharness",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Per-symbol maintenance optimizer for an agent's skill layer — learns skills from real runs and keeps them by adherence in use, not by an offline eval score.",
   "author": { "name": "Tigerless Labs" },
   "homepage": "https://github.com/tigerless-labs/autoharness",

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <h1 align="center">autoharness</h1>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/release-v0.2.2-brightgreen.svg" alt="release" />
+  <img src="https://img.shields.io/badge/release-v0.2.3-brightgreen.svg" alt="release" />
   <img src="https://img.shields.io/badge/python-3.11%2B-blue.svg" alt="python" />
   <img src="https://img.shields.io/badge/platform-Linux%20%7C%20macOS-lightgrey.svg" alt="platform" />
   <img src="https://img.shields.io/badge/license-MIT-yellow.svg" alt="license MIT" />

--- a/agents/reflector.md
+++ b/agents/reflector.md
@@ -13,7 +13,7 @@ You only ever **propose**. You have no Write, Edit, or Bash. Your single write f
 
 Your input already contains three things; read them, don't search for them:
 
-1. A redacted window of the most recent exchanges — the episode trace.
+1. A redacted raw slice of the host transcript (JSONL events) since the last reflection — the episode trace. It contains tool results, meta records, and truncation marks verbatim; read past the noise to the user/assistant story.
 2. A description index of every existing skill across both layers (`global` and `project`), as `name [layer]: description`.
 3. The authoring + format spec the skill must satisfy. Write to **this** spec — do not infer format from existing skills.
 

--- a/src/autoharness/config.py
+++ b/src/autoharness/config.py
@@ -18,7 +18,12 @@ def _int_env(name, default):
         return default
 
 
-REFLECT_EVERY_N = _int_env("AUTOHARNESS_REFLECT_EVERY_N", 3)  # trigger cadence == size of the window fed to REF
+REFLECT_EVERY_N = _int_env("AUTOHARNESS_REFLECT_EVERY_N", 3)  # trigger cadence; the window itself is watermark-delimited (capture)
+
+# raw-capture byte caps (ponytail: placeholders, calibrate in experiments/): per transcript record,
+# and per handoff window (tail kept) — bound tool dumps / base64 away from the child context.
+CAPTURE_MAX_RECORD_BYTES = 4_000
+CAPTURE_MAX_WINDOW_BYTES = 200_000
 
 STAGE_MAX_BODY_BYTES = 100_000  # ponytail: placeholder, SKILL.md body cap; for instant feedback on stage_skill args
 

--- a/src/autoharness/hook/capture.py
+++ b/src/autoharness/hook/capture.py
@@ -1,78 +1,44 @@
-"""CAP handoff artifact: at trigger time, take a redacted tail-N window from the host transcript and materialize it for the reflector to read across processes.
+"""CAP handoff window: a raw byte slice of the host transcript since the last reflection — zero parsing.
 
-cap.md: CAP copies zero content — no trigger, no copy; on trigger take the most recent N exchanges
-(N == reflect_every_n, same count as the trigger cadence, zero overlap), pass the egress red line
-(redact), and atomically materialize to the handoff path. **Never write back to the host raw log**
-(it is not ours). Redaction happens at the moment of materializing to the downstream, not as a stored
-copy at some entry point.
-
-ponytail: exchange splitting = an assumption about the host format (a user role starts a new window,
-role/text extracted with field-tolerant fallbacks). Whether tail-N captures the original turns under
-the real Claude Code .jsonl schema + compaction = Phase 0 live spike (cap.md open); parsing is tested
-on fixtures for invariants, recalibrated once the spike pins down the real format.
+cap.md + docs/plans/raw-capture.md: the transcript is the host's internal event log, not a chat log;
+any role/text extraction here is a format assumption that live windows proved wrong (meta records as
+empty roles, tool results as pseudo-user turns). So capture does not interpret the format at all —
+the reflector (an LLM) reads raw JSONL fine. capture only moves bytes: slice from the session's byte
+watermark to EOF, clip oversized records and the window total (tool dumps / base64 must not blow the
+child context), pass the egress red line (redact), and hand the text plus the new watermark back to
+the caller. **Never write back to the host raw log** (it is not ours). A missing / stale / negative
+watermark (compaction rewrote the file) fails safe to a full re-read bounded by the window cap.
 """
-import json
 from pathlib import Path
 
-from autoharness.lib import atomic, redact
+from autoharness import config
+from autoharness.lib import redact
+
+TRUNCATION_MARK = "...[truncated]"
 
 
-def _records(transcript_path):
-    p = Path(transcript_path)
-    if not p.exists():
-        return []
-    records = []
-    for line in p.read_text().splitlines():
-        line = line.strip()
-        if not line:
-            continue
-        try:
-            records.append(json.loads(line))
-        except json.JSONDecodeError:
-            continue
-    return records
+def _clip(line, cap):
+    return line if len(line) <= cap else line[:cap] + TRUNCATION_MARK
 
 
-def _role(rec):
-    return str(rec.get("role") or rec.get("type") or "")
-
-
-def _text(rec):
-    msg = rec.get("message") if isinstance(rec.get("message"), dict) else rec
-    content = msg.get("content", msg.get("text", ""))
-    if isinstance(content, str):
-        return content
-    if isinstance(content, list):
-        parts = []
-        for block in content:
-            if isinstance(block, dict):
-                parts.append(str(block.get("text") or block.get("content") or ""))
-            else:
-                parts.append(str(block))
-        return " ".join(p for p in parts if p)
-    return str(content)
-
-
-def _exchanges(records):
-    exchanges, current = [], []
-    for rec in records:
-        if _role(rec).startswith("user") and current:
-            exchanges.append(current)
-            current = []
-        current.append(rec)
-    if current:
-        exchanges.append(current)
-    return exchanges
-
-
-def window(transcript_path, n, *, rules_path=None):
-    if n <= 0:
-        return ""
-    tail = _exchanges(_records(transcript_path))[-n:]
-    lines = [f"{_role(rec)}: {_text(rec)}" for ex in tail for rec in ex]
-    return redact.redact("\n".join(lines), rules_path)
-
-
-def materialize(transcript_path, n, dest, *, rules_path=None):
-    atomic.write_text(dest, window(transcript_path, n, rules_path=rules_path))
-    return dest
+def window(transcript_path, offset=0, *, max_record_bytes=None, max_window_bytes=None,
+           rules_path=None):
+    record_cap = max_record_bytes or config.CAPTURE_MAX_RECORD_BYTES
+    window_cap = max_window_bytes or config.CAPTURE_MAX_WINDOW_BYTES
+    path = Path(transcript_path)
+    if not path.exists():
+        return "", 0
+    data = path.read_bytes()
+    new_offset = len(data)
+    if not 0 <= offset <= new_offset:
+        offset = 0
+    lines = [_clip(line, record_cap)
+             for line in data[offset:].decode("utf-8", errors="replace").splitlines()]
+    kept, total = [], 0
+    for line in reversed(lines):
+        total += len(line) + 1
+        if total > window_cap:
+            kept.append(TRUNCATION_MARK)
+            break
+        kept.append(line)
+    return redact.redact("\n".join(reversed(kept)), rules_path), new_offset

--- a/src/autoharness/hook/dispatch.py
+++ b/src/autoharness/hook/dispatch.py
@@ -41,10 +41,10 @@ def _is_reflector(event):
     return at == config.REFLECTOR_AGENT or at.endswith("reflector")
 
 
-def _detached_launch(transcript_path, window_n, run_id, roots):
+def _detached_launch(transcript_path, session_id, run_id, roots):
     subprocess.Popen(  # host-detach: fire-and-forget so the Stop hook returns immediately
         [sys.executable, "-m", "autoharness.hook.spawn",
-         str(transcript_path), str(window_n), run_id,
+         str(transcript_path), str(session_id), run_id,
          str(roots[layer.PROJECT]), str(roots[layer.GLOBAL])],
         start_new_session=True, stdin=subprocess.DEVNULL,
         stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
@@ -55,7 +55,7 @@ def _reflect(event, result, roots, launch=None):
     transcript_path = event.get("transcript_path")
     if not transcript_path:
         return
-    (launch or _detached_launch)(transcript_path, result.get("window_n", 0), _run_id(result), roots)
+    (launch or _detached_launch)(transcript_path, result.get("session_id", ""), _run_id(result), roots)
 
 
 def dispatch(event, *, roots=None, reflect=None):

--- a/src/autoharness/hook/on_stop.py
+++ b/src/autoharness/hook/on_stop.py
@@ -3,8 +3,8 @@
 cap.md: the only signal for "each response ended" is Stop. But Stop = per turn while an episode = a task
 spanning many turns, so we do not spawn on every Stop — read a small int and +1 (O(1), no transcript
 scan), and only emit a trigger verdict and reset once reflect_every_n is reached. The detached spawn
-itself connects to Phase 5 spawn.py; this step only emits "trigger or not + window N", and spawn uses it
-to call capture.materialize (window N == threshold, same count as the trigger cadence, zero overlap).
+itself connects to Phase 5 spawn.py; this step only emits the trigger verdict — the window itself is
+watermark-delimited by capture (raw bytes since the last reflection, zero overlap by construction).
 
 Recursion guard: a reflector child session's Stop (CHILD_SESSION_ENV set) must neither re-trigger
 reflection nor count, otherwise infinite self-reflection. Bad/missing session-id → no trigger

--- a/src/autoharness/hook/spawn.py
+++ b/src/autoharness/hook/spawn.py
@@ -17,7 +17,7 @@ from pathlib import Path
 
 from autoharness import config
 from autoharness.hook import capture, promoter
-from autoharness.lib import atomic, layer, skill_store, validate
+from autoharness.lib import atomic, counters, layer, skill_store, validate
 
 
 def description_index(roots=None):
@@ -81,9 +81,13 @@ def run(window_text, run_id, *, roots, repo_name=None, agent=None, claude_bin=No
 
 
 def main(argv=None):
-    transcript_path, n, run_id, proot, groot = argv if argv is not None else sys.argv[1:]
+    transcript_path, session_id, run_id, proot, groot = argv if argv is not None else sys.argv[1:]
     roots = {layer.PROJECT: Path(proot), layer.GLOBAL: Path(groot)}
-    run(capture.window(transcript_path, int(n)), run_id, roots=roots)
+    offset = counters.session_offset(session_id, roots[layer.PROJECT])
+    window_text, new_offset = capture.window(transcript_path, offset)
+    result = run(window_text, run_id, roots=roots)
+    counters.write_session_offset(session_id, new_offset, roots[layer.PROJECT])
+    return result
 
 
 if __name__ == "__main__":

--- a/src/autoharness/lib/counters.py
+++ b/src/autoharness/lib/counters.py
@@ -58,3 +58,17 @@ def clear_session(session_id, root=None):
     p = _session_path(session_id, root)
     if p.exists():
         p.unlink()
+
+
+def _offset_path(session_id, root=None):
+    if not isinstance(session_id, str) or not _SAFE_SESSION.match(session_id):
+        raise ValueError(f"unsafe session id: {session_id!r}")
+    return layer.state_dir(layer.PROJECT, root) / f"offset-{session_id}"
+
+
+def session_offset(session_id, root=None):
+    return _read_int(_offset_path(session_id, root))
+
+
+def write_session_offset(session_id, offset, root=None):
+    atomic.write_text(_offset_path(session_id, root), str(int(offset)))

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -3,52 +3,82 @@ import json
 from autoharness.hook import capture
 
 
-def _write_transcript(p, exchanges):
-    lines = []
-    for user_text, assistant_text in exchanges:
-        lines.append(json.dumps({"type": "user", "message": {"role": "user", "content": user_text}}))
-        lines.append(json.dumps({"type": "assistant",
-                                 "message": {"role": "assistant", "content": assistant_text}}))
-    p.write_text("\n".join(lines) + "\n")
+def _write_transcript(p, records):
+    p.write_text("\n".join(json.dumps(r) for r in records) + "\n")
 
 
-def _users(window_text):
-    return [ln for ln in window_text.splitlines() if ln.startswith("user:")]
+def _record(i, text=None):
+    return {"type": "user", "message": {"role": "user", "content": text or f"q{i}"}}
 
 
-def test_window_takes_tail_n_exchanges(tmp_path):
+def test_window_returns_raw_slice_and_new_offset(tmp_path):
     t = tmp_path / "transcript.jsonl"
-    _write_transcript(t, [(f"q{i}", f"a{i}") for i in range(5)])
-    w = capture.window(t, 2)
-    assert "q3" in w and "q4" in w
-    assert "q0" not in w and "q2" not in w
+    _write_transcript(t, [_record(i) for i in range(3)])
+    text, offset = capture.window(t)
+    assert offset == t.stat().st_size
+    for i in range(3):
+        assert f"q{i}" in text
+    assert json.loads(text.splitlines()[0])["type"] == "user"
 
 
-def test_window_size_equals_n_zero_overlap(tmp_path):
+def test_window_incremental_zero_overlap(tmp_path):
     t = tmp_path / "transcript.jsonl"
-    _write_transcript(t, [(f"q{i}", f"a{i}") for i in range(10)])
-    assert len(_users(capture.window(t, 3))) == 3
+    _write_transcript(t, [_record(0), _record(1)])
+    first, offset = capture.window(t)
+    with t.open("a") as f:
+        f.write(json.dumps(_record(2)) + "\n")
+    second, new_offset = capture.window(t, offset)
+    assert "q2" in second
+    assert "q0" not in second and "q1" not in second
+    assert new_offset > offset
+
+
+def test_window_bad_offset_resets_to_full(tmp_path):
+    t = tmp_path / "transcript.jsonl"
+    _write_transcript(t, [_record(0)])
+    for bad in (t.stat().st_size + 999, -5):
+        text, offset = capture.window(t, bad)
+        assert "q0" in text
+        assert offset == t.stat().st_size
+
+
+def test_window_clips_oversized_record(tmp_path):
+    t = tmp_path / "transcript.jsonl"
+    _write_transcript(t, [_record(0, text="x" * 500), _record(1)])
+    text, _ = capture.window(t, max_record_bytes=100)
+    lines = text.splitlines()
+    assert all(len(ln) < 200 for ln in lines)
+    assert "truncated" in text
+    assert "q1" in text
+
+
+def test_window_total_cap_keeps_tail(tmp_path):
+    t = tmp_path / "transcript.jsonl"
+    _write_transcript(t, [_record(i) for i in range(50)])
+    text, offset = capture.window(t, max_window_bytes=300)
+    assert len(text) < 1000
+    assert "q49" in text and "q0" not in text
+    assert "truncated" in text
+    assert offset == t.stat().st_size
 
 
 def test_window_redacts_egress(tmp_path):
     t = tmp_path / "transcript.jsonl"
-    _write_transcript(t, [("my key is AKIAIOSFODNN7EXAMPLE", "mail me jane.doe@example.com")])
-    w = capture.window(t, 1)
-    assert "AKIAIOSFODNN7EXAMPLE" not in w
-    assert "jane.doe@example.com" not in w
-    assert "[REDACTED:" in w
+    _write_transcript(t, [_record(0, text="my key is AKIAIOSFODNN7EXAMPLE"),
+                          _record(1, text="mail me jane.doe@example.com")])
+    text, _ = capture.window(t)
+    assert "AKIAIOSFODNN7EXAMPLE" not in text
+    assert "jane.doe@example.com" not in text
+    assert "[REDACTED:" in text
 
 
-def test_materialize_atomic_no_source_mutation(tmp_path):
+def test_window_never_mutates_source(tmp_path):
     t = tmp_path / "transcript.jsonl"
-    _write_transcript(t, [("secret AKIAIOSFODNN7EXAMPLE here", "ok")])
+    _write_transcript(t, [_record(0, text="secret AKIAIOSFODNN7EXAMPLE here")])
     before = t.read_bytes()
-    dest = tmp_path / "state" / "window.md"
-    out = capture.materialize(t, 1, dest)
-    assert out == dest and dest.exists()
-    assert t.read_bytes() == before  # host raw log bytes unchanged
-    assert "AKIAIOSFODNN7EXAMPLE" not in dest.read_text()  # materialized window is redacted
+    capture.window(t)
+    assert t.read_bytes() == before
 
 
 def test_window_missing_transcript_empty(tmp_path):
-    assert capture.window(tmp_path / "nope.jsonl", 5) == ""
+    assert capture.window(tmp_path / "nope.jsonl") == ("", 0)

--- a/tests/test_counters.py
+++ b/tests/test_counters.py
@@ -40,3 +40,20 @@ def test_unknown_layer_rejected(tmp_path):
 def test_session_id_traversal_rejected(tmp_path):
     with pytest.raises(ValueError):
         counters.bump_session("../evil", tmp_path)
+
+
+def test_session_offset_roundtrip_default_zero(tmp_path):
+    assert counters.session_offset("s1", tmp_path) == 0
+    counters.write_session_offset("s1", 12345, tmp_path)
+    assert counters.session_offset("s1", tmp_path) == 12345
+
+
+def test_session_offset_garbage_reads_zero(tmp_path):
+    counters.write_session_offset("s2", 7, tmp_path)
+    counters._offset_path("s2", tmp_path).write_text("not-a-number")
+    assert counters.session_offset("s2", tmp_path) == 0
+
+
+def test_session_offset_traversal_rejected(tmp_path):
+    with pytest.raises(ValueError):
+        counters.write_session_offset("../evil", 1, tmp_path)

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -124,8 +124,8 @@ def test_reflect_builds_run_id_and_skips_without_transcript(tmp_path):
     launched = []
     result = {"session_id": "abc", "count": 7, "window_n": 7}
     dispatch._reflect({"transcript_path": "/t.jsonl"}, result, _roots(tmp_path),
-                      launch=lambda tp, n, run_id, roots: launched.append((tp, n, run_id)))
-    assert launched == [("/t.jsonl", 7, "abc-7")]
+                      launch=lambda tp, sid, run_id, roots: launched.append((tp, sid, run_id)))
+    assert launched == [("/t.jsonl", "abc", "abc-7")]
 
     launched.clear()
     dispatch._reflect({}, result, _roots(tmp_path), launch=lambda *a: launched.append(a))

--- a/tests/test_lifecycle_e2e.py
+++ b/tests/test_lifecycle_e2e.py
@@ -52,7 +52,7 @@ def test_full_skill_lifecycle_through_dispatch(tmp_path, capsys):
                                 {"action": "create", "name": "learned", "level": "project",
                                  "body": LEARNED, "reason": "captured repeat", "evidence": "slice"},
                                 rts[layer.PROJECT])
-        spawn.run(capture.window(event["transcript_path"], result["window_n"]),
+        spawn.run(capture.window(event["transcript_path"])[0],
                   dispatch._run_id(result), roots=rts, spawn_fn=fake_spawn)
 
     # BEAT 1 — birth: drive Stops until the cadence triggers reflection

--- a/tests/test_spawn.py
+++ b/tests/test_spawn.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 from autoharness import config
 from autoharness.hook import spawn
-from autoharness.lib import layer, ledger, sidecar, skill_store
+from autoharness.lib import counters, layer, ledger, sidecar, skill_store
 
 _SRC = str(Path(__file__).resolve().parents[1] / "src")
 
@@ -14,15 +14,27 @@ def _roots(tmp_path):
 
 
 def test_main_parses_argv_and_runs(tmp_path, monkeypatch):
-    monkeypatch.setattr(spawn.capture, "window", lambda tp, n, **k: f"WIN[{tp}|{n}]")
+    monkeypatch.setattr(spawn.capture, "window", lambda tp, off, **k: (f"WIN[{tp}|{off}]", 42))
     seen = {}
     monkeypatch.setattr(spawn, "run",
                         lambda w, rid, **k: seen.update(w=w, rid=rid, roots=k["roots"]))
-    spawn.main(["/t.jsonl", "5", "run-9", str(tmp_path / "p"), str(tmp_path / "g")])
-    assert seen["w"] == "WIN[/t.jsonl|5]"
+    spawn.main(["/t.jsonl", "sess-1", "run-9", str(tmp_path / "p"), str(tmp_path / "g")])
+    assert seen["w"] == "WIN[/t.jsonl|0]"
     assert seen["rid"] == "run-9"
     assert seen["roots"][layer.PROJECT] == tmp_path / "p"
     assert seen["roots"][layer.GLOBAL] == tmp_path / "g"
+    assert counters.session_offset("sess-1", tmp_path / "p") == 42
+
+
+def test_main_offset_advances_only_after_run(tmp_path, monkeypatch):
+    monkeypatch.setattr(spawn.capture, "window", lambda tp, off, **k: ("W", 99))
+    monkeypatch.setattr(spawn, "run", lambda *a, **k: (_ for _ in ()).throw(RuntimeError("boom")))
+    counters.write_session_offset("sess-2", 7, tmp_path / "p")
+    try:
+        spawn.main(["/t.jsonl", "sess-2", "run-1", str(tmp_path / "p"), str(tmp_path / "g")])
+    except RuntimeError:
+        pass
+    assert counters.session_offset("sess-2", tmp_path / "p") == 7  # crash -> window re-fed next time
 
 
 # --- U3 deterministic assembly ---


### PR DESCRIPTION
## Problem
Live handoff windows showed the exchange parser misreading the real Claude Code transcript: meta records (`file-history-snapshot`, `relocated`, ...) rendered as empty role lines, tool results counted as user turns, and exchange splitting misaligned — half the reflector's window was noise.

## Fix
Capture stops interpreting the transcript format entirely (`json.loads` gone):
- **Byte watermark per session** (`offset-<session>` in project state): window = raw bytes from last watermark to EOF. Zero overlap by construction; `window_n` removed from the launch chain.
- **Two retained gates**: redaction (egress red line) and byte caps (per-record clip + window-total tail-keep, new config knobs) so tool dumps / base64 can't blow the child context.
- **At-least-once**: the watermark advances only after a successful spawn+drain; a crash re-feeds the window. Stale/negative offsets (compaction) fail safe to a capped full re-read.
- Reflector agent prompt updated to describe the raw JSONL slice.

## Verification
- 245 unit/system tests pass (capture rewritten test-first; counters offset roundtrip/garbage/traversal; spawn advances offset only after run).
- E2E on a real session transcript: first window is the raw slice; appending one record and re-running yields exactly that one record; offset advances.

Plan: `docs/plans/raw-capture.md` (local).