### PR TITLE
chore: drop handoff persistence; release v0.2.4

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autoharness",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Per-symbol maintenance optimizer for an agent's skill layer — learns skills from real runs and keeps them by adherence in use, not by an offline eval score.",
   "author": { "name": "Tigerless Labs" },
   "homepage": "https://github.com/tigerless-labs/autoharness",

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <h1 align="center">autoharness</h1>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/release-v0.2.3-brightgreen.svg" alt="release" />
+  <img src="https://img.shields.io/badge/release-v0.2.4-brightgreen.svg" alt="release" />
   <img src="https://img.shields.io/badge/python-3.11%2B-blue.svg" alt="python" />
   <img src="https://img.shields.io/badge/platform-Linux%20%7C%20macOS-lightgrey.svg" alt="platform" />
   <img src="https://img.shields.io/badge/license-MIT-yellow.svg" alt="license MIT" />

--- a/src/autoharness/hook/spawn.py
+++ b/src/autoharness/hook/spawn.py
@@ -2,8 +2,8 @@
 
 architecture line 29 / [reflector-subagent] / [cap]: at trigger time CAP gives "redacted episode window +
 trigger cadence"; this step assembles the three pieces (window + the existing skill description index
-(compare-first dedupe source, skips archived) + the single-source format_spec), persists them to disk,
-and feeds them via stdin to the cross-process reflector. spawn sets CHILD_SESSION_ENV (recursion guard) +
+(compare-first dedupe source, skips archived) + the single-source format_spec) and feeds them via
+stdin to the cross-process reflector — nothing is persisted; the bundle lives only in the pipe. spawn sets CHILD_SESSION_ENV (recursion guard) +
 injects run_id/root via env (stage_skill uses these to append back to the queue), then drains the intent
 queue to disk after the child session ends. Authoring and landing are fully split across processes from
 here: the reflector only appends intents, the promoter exclusively validates and lands.
@@ -17,7 +17,7 @@ from pathlib import Path
 
 from autoharness import config
 from autoharness.hook import capture, promoter
-from autoharness.lib import atomic, counters, layer, skill_store, validate
+from autoharness.lib import counters, layer, skill_store, validate
 
 
 def description_index(roots=None):
@@ -70,7 +70,6 @@ def run(window_text, run_id, *, roots, repo_name=None, agent=None, claude_bin=No
     proot = roots.get(layer.PROJECT)
     spec = (spec_path or config.FORMAT_SPEC).read_text()
     bundle = build_bundle(window_text, description_index(roots), spec)
-    atomic.write_text(layer.state_dir(layer.PROJECT, proot) / "handoff" / f"{run_id}.md", bundle)
 
     argv = build_command(agent=agent or config.REFLECTOR_AGENT,
                          claude_bin=claude_bin or config.CLAUDE_BIN)

--- a/tests/test_spawn.py
+++ b/tests/test_spawn.py
@@ -85,7 +85,7 @@ def test_child_env_sets_guard_and_coords_without_polluting():
 
 # --- U4 run orchestration + system (fake reflector) ---
 
-def test_run_materializes_handoff_and_drains(tmp_path):
+def test_run_feeds_bundle_and_drains_no_handoff_persisted(tmp_path):
     roots = _roots(tmp_path)
     seen = {}
 
@@ -106,6 +106,7 @@ def test_run_materializes_handoff_and_drains(tmp_path):
     assert "WINDOW" in seen["bundle"]
     assert [v["ok"] for v in verdicts] == [True]
     assert skill_store.read_body("project", "learned", roots["project"]) is not None
+    assert not (layer.state_dir(layer.PROJECT, roots["project"]) / "handoff").exists()  # bundle lives only in the pipe
 
 
 def _fake_reflector_script(tmp_path):


### PR DESCRIPTION
The handoff/<run_id>.md file was a write-only audit copy of the reflector bundle (the reflector receives the same bytes on stdin and never reads the file; nothing else does either). Remove the persistence; the bundle now lives only in the pipe. Test asserts no handoff dir is created.