### PR TITLE
fix: placeholder false positive on TODO.md mentions; release v0.2.5

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autoharness",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Per-symbol maintenance optimizer for an agent's skill layer — learns skills from real runs and keeps them by adherence in use, not by an offline eval score.",
   "author": { "name": "Tigerless Labs" },
   "homepage": "https://github.com/tigerless-labs/autoharness",

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <h1 align="center">autoharness</h1>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/release-v0.2.4-brightgreen.svg" alt="release" />
+  <img src="https://img.shields.io/badge/release-v0.2.5-brightgreen.svg" alt="release" />
   <img src="https://img.shields.io/badge/python-3.11%2B-blue.svg" alt="python" />
   <img src="https://img.shields.io/badge/platform-Linux%20%7C%20macOS-lightgrey.svg" alt="platform" />
   <img src="https://img.shields.io/badge/license-MIT-yellow.svg" alt="license MIT" />

--- a/src/autoharness/lib/validate.py
+++ b/src/autoharness/lib/validate.py
@@ -24,7 +24,7 @@ from autoharness import config
 from autoharness.lib import layer, skills_guard
 
 _FRONTMATTER = re.compile(r"\A---\n(.*?)\n---\n?", re.DOTALL)
-_PLACEHOLDER = re.compile(r"\b(TODO|FIXME|XXX)\b|<[A-Z][A-Z_]{2,}>")
+_PLACEHOLDER = re.compile(r"\b(TODO|FIXME|XXX):|<[A-Z][A-Z_]{2,}>")
 _ABS_PATH = re.compile(r"(?:/home/|/Users/|/root/)[^\s`)\]]+|[A-Za-z]:\\[^\s`)\]]+")
 _PY_REF = re.compile(r"[\w./-]+\.py")
 _SUBFILE_REF = re.compile(r"\b(?:{})/[A-Za-z0-9._/-]+".format("|".join(layer.SUBFILE_DIRS)))

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -34,6 +34,12 @@ def test_completeness_placeholder_rejected():
     assert "completeness" in _families(validate.validate(GOOD_INTENT, body))
 
 
+def test_placeholder_mention_without_colon_passes():
+    body = ("---\nname: foo\ndescription: d\n---\n# Foo\n"
+            "Recorded in docs/TODO.md; we track TODOs there. FIXME.md too.\n")
+    assert not [f for f in validate.structure(body) if f[0] == "completeness"]
+
+
 def test_global_repo_agnostic_rejected_but_project_ok():
     body = "---\nname: foo\ndescription: d\n---\nRun /home/ryan/tigerless_ai/x.py\n"
     assert "global_repo_agnostic" in _families(validate.validate({**GOOD_INTENT, "level": "global"}, body))


### PR DESCRIPTION
A live reflector staged a valid folder-skill whose body said "Recorded in docs/TODO.md"; the promoter's completeness check matched the bare word `TODO` and silently rejected it — the first real skill this plugin produced died to its own validator.

Fix: the placeholder regex now requires the conventional colon (`TODO:`/`FIXME:`/`XXX:`); `<ALL_CAPS>` templates still match. Regression test added (mentions of TODO.md / "TODOs" pass; `TODO: finish this` still rejected). The originally rejected intent validates OK under the new rule. 246 tests pass.