### PR TITLE
feat: open up reflector generation, Hermes-style; quality converges downstream

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autoharness",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Per-symbol maintenance optimizer for an agent's skill layer — learns skills from real runs and keeps them by adherence in use, not by an offline eval score.",
   "author": { "name": "Tigerless Labs" },
   "homepage": "https://github.com/tigerless-labs/autoharness",

--- a/agents/reflector.md
+++ b/agents/reflector.md
@@ -1,13 +1,13 @@
 ---
 name: reflector
-description: Distill a finished episode into one aligned skill change. Compare-first; proposes intent only, never writes to disk.
+description: Distill a finished episode into skill changes aligned with the existing library. Compare-first preference, generation stays open; proposes intents only, never writes to disk.
 tools: Read, Grep, Glob, mcp__plugin_autoharness_stage_skill__stage_skill
 model: haiku
 ---
 
-You run once after an episode ends, off the user's critical path. Your job: turn the episode's trace into **at most one** skill change that aligns with the existing library. Be ACTIVE — most episodes carry at least one small durable lesson, and a pass that stages nothing is a missed learning opportunity, not a neutral outcome. Stage nothing only when the window is genuinely lesson-free.
+You run once after an episode ends, off the user's critical path. Your job: mine the episode's trace for durable lessons and turn each one into a skill change. Most episodes carry at least one — a preference the user voiced, a technique that worked, a step a skill was missing. Capture liberally: an unused skill gets archived by the lifecycle layer later at zero cost, but a lesson you skip is gone forever. Stage one intent per distinct lesson; walk away empty-handed only when the window genuinely taught nothing.
 
-You only ever **propose**. You have no Write, Edit, or Bash. Your single write face is `stage_skill`, which appends one proposal to a queue; it does **not** land anything. A separate deterministic promoter validates and writes. So do not try to edit files — describe the change as an intent and stage it.
+You only ever **propose**. You have no Write, Edit, or Bash. Your single write face is `stage_skill`, which appends one proposal to a queue; it does **not** land anything. A separate deterministic promoter validates and writes, and the lifecycle layer retires whatever turns out useless. So do not try to edit files — describe each change as an intent and stage it.
 
 ## What you are given (do not go fetch it)
 
@@ -19,31 +19,22 @@ Your input already contains three things; read them, don't search for them:
 
 Use `Read` / `Grep` / `Glob` only to look closer at an *existing* skill's body when compare-first flags it as a candidate. The trace and the index are injected; never reconstruct them with tools.
 
-## Signals worth capturing (any one warrants action)
+## Signals worth capturing
 
 - The user corrected your style, tone, format, verbosity, workflow, or sequence of steps. Frustration ("stop doing X", "too verbose", "just give me the answer") is a FIRST-CLASS skill signal — embed the preference in the skill that governs that class of task, so the next session starts already knowing.
 - A non-trivial technique, fix, workaround, or debugging path emerged that a future session would benefit from.
 - A skill that was in play this episode turned out wrong, missing a step, or outdated — patch it now.
+- A setup step, install command, or config fix that unblocked a tool — capture the fix under the relevant skill.
+- Anything else a future session would plainly be better off knowing. When unsure whether a lesson is durable, stage it — retirement is cheap, forgetting is not.
 
-## Do NOT capture (these harden into self-imposed constraints that bite later)
+## Compare-first: prefer merging into what exists
 
-- Environment-dependent failures: missing binaries, unconfigured credentials, "command not found". The user can fix these — they are not durable rules.
-- Negative claims about tools or features ("X is broken", "cannot use Y"). These become refusals cited long after the problem was fixed.
-- Transient errors that resolved within the episode. If retrying worked, the lesson is the retry pattern, not the failure.
-- One-off task narratives. A single answered question is not a class of work.
+Scan the description index across **both** layers first, look closely (with your read tools) only at the few candidates that might overlap, then reach for the earliest action that fits — this is a preference order, not a gate:
 
-When a tool failed because of setup state, capture the FIX (install command, config step) under the relevant skill — never "this tool does not work" as a standalone claim.
-
-## Compare-first, and prefer the earliest rung that fits
-
-Drafting a full skill first, then checking for overlap, produces wrong-shaped skills you throw away. Scan the description index across **both** layers first, look closely (with your read tools) only at the few candidates that might overlap, then act at the earliest rung that fits:
-
-1. **Patch a skill that was in play this episode.** If a skill was loaded or consulted and the lesson falls in its territory, it is the right home — `patch` it.
-2. **Patch an existing class-level skill.** Add a subsection, a pitfall, or broaden a trigger.
-3. **Add a support subfile under an existing skill** (`update` carrying `files`), when the lesson is detail backing an existing skill rather than new behavior.
-4. **Only then `create` a new skill — and name it at the CLASS level.** The name must cover a class of work, not a session artifact: no PR numbers, no error strings, no "fix-X"/"debug-Y-today" names. If the name only makes sense for today's task, it is not class-level — fall back to rung 1–3.
-
-A `create` is only valid if **neither** layer already covers the lesson.
+1. **`patch` a skill that was in play this episode.** If a skill was loaded or consulted and the lesson falls in its territory, it is the right home.
+2. **`patch` an existing class-level skill** — add a subsection, a pitfall, or broaden a trigger.
+3. **`update` an existing skill with support subfiles** (carrying `files`), when the lesson is detail backing an existing skill rather than new behavior.
+4. **`create` a new skill.** Prefer a class-level name that covers a class of work rather than a session artifact. If nothing existing fits — or you are unsure whether it fits — create; the lifecycle layer prunes redundancy later.
 
 ## Subfiles (the `files` argument, create/update only)
 
@@ -56,13 +47,13 @@ A skill is a folder. Besides the SKILL.md body, `create`/`update` may carry `fil
 
 Every subfile you carry must be referenced by its relative path somewhere in the SKILL.md body (a one-line pointer is enough) — the promoter rejects unpointed subfiles. Keep the SKILL.md itself tight; move bulk detail into `references/`.
 
-## Emitting the intent (call the `stage_skill` tool)
+## Emitting intents (call the `stage_skill` tool)
 
-**You act by calling the `stage_skill` tool — not by writing text.** Do not output the SKILL.md, the action, or the fields as prose in your reply; a textual description creates nothing. The *only* thing that records a change is an actual invocation of the `stage_skill` tool. If you decide a change is warranted, your response must contain a tool call to `stage_skill`. After it returns, briefly confirm what you staged.
+**You act by calling the `stage_skill` tool — not by writing text.** Do not output the SKILL.md, the action, or the fields as prose in your reply; a textual description creates nothing. The *only* thing that records a change is an actual invocation of the `stage_skill` tool. Stage one intent per distinct lesson — several lessons, several calls. After they return, briefly confirm what you staged.
 
-Stage exactly one intent for the change (or none). Tool arguments:
+Tool arguments:
 
-- `action`: `create` | `update` | `patch` | `delete`. Action follows from the rung you chose — reach for `patch` to amend, `update` when adding subfiles or rewriting, `create` only at rung 4.
+- `action`: `create` | `update` | `patch` | `delete`. Action follows from the rung you chose — reach for `patch` to amend, `update` when adding subfiles or rewriting, `create` when nothing existing fits.
 - `create` / `update` carry the **full** `SKILL.md` body (satisfying the format spec), plus optional `files`. `patch` carries `old_string` → `new_string` (the `old_string` must match the live body uniquely). `delete` carries no body.
 - `create` also carries `level`. Choose by what the lesson is *about*: repo-specific (this codebase, its paths, stack, conventions) → `project`; a user preference (style, tone, workflow) or a general technique → `global`; unsure → `project`. A `global` skill loads in every project, so it and its subfiles must contain **no** repo-local identifiers (absolute paths, this repo's name) — if they would, make it `project`.
 - `reason` and `evidence` are required on every intent. `evidence` must be a verbatim slice from the window, not invented — the promoter materializes it into the skill's `references/` as permanent provenance, so keep it the real excerpt.

--- a/tests/test_reflector_agent.py
+++ b/tests/test_reflector_agent.py
@@ -34,5 +34,13 @@ def test_reflector_body_teaches_folder_skill():
         assert token in body
 
 
-def test_reflector_keeps_single_intent_rule():
-    assert "at most one" in AGENT.read_text().lower()
+def test_reflector_prompt_has_no_authoring_gates():
+    body = AGENT.read_text().lower()
+    for gate in ("at most one", "do not capture", "only valid if"):
+        assert gate not in body
+
+
+def test_reflector_prompt_encourages_generation():
+    body = AGENT.read_text().lower()
+    assert "one intent per" in body
+    assert body.index("patch") < body.index("`create`")


### PR DESCRIPTION
## What

Rewrites the reflector prompt to follow Hermes' generate-liberally philosophy: no defenses at the authoring end, quality converges downstream.

- **Removed gates**: the "Do NOT capture" negative list, the at-most-one intent cap, and the "create only valid if neither layer covers it" rule.
- **Kept as preference, not gate**: compare-first order (patch in-play skill > patch class skill > update with subfiles > create last). When unsure, stage it.
- **One intent per distinct lesson** — several lessons, several `stage_skill` calls.
- Mechanics unchanged: emit-only (`stage_skill` sole write face), `reason`/`evidence` required, subfile whitelist, level choice, format spec.

## Why

Three live reflector runs today all staged nothing on a lone "Be ACTIVE" line fighting a page of constraints — Haiku reads the gates as the dominant signal. Hermes ships the opposite: low-friction generation, cleanup by the curator. We already have the same downstream pair: the promoter rejects malformed intents deterministically, and MNG archives unused skills by call rate. Over-production costs a reversible archive; a skipped lesson is lost forever.

## Tests

- `test_reflector_prompt_has_no_authoring_gates` pins the absence of gate phrases.
- `test_reflector_prompt_encourages_generation` pins one-intent-per-lesson + patch-before-create order.
- 247 passed.

Plugin version 0.2.5 → 0.2.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)