### PR TITLE
fix: capacity contention is the only death; land skills with a real anchor

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autoharness",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Per-symbol maintenance optimizer for an agent's skill layer — learns skills from real runs and keeps them by adherence in use, not by an offline eval score.",
   "author": { "name": "Tigerless Labs" },
   "homepage": "https://github.com/tigerless-labs/autoharness",

--- a/src/autoharness/hook/dispatch.py
+++ b/src/autoharness/hook/dispatch.py
@@ -15,6 +15,7 @@ platform contract pins the details:
 ponytail: detached launch is a fire-and-forget Popen; robustness of orphan / timeout isolation left for observation.
 """
 import json
+import os
 import re
 import subprocess
 import sys
@@ -67,6 +68,8 @@ def dispatch(event, *, roots=None, reflect=None):
         if name == "SessionStart":
             return {"handled": name, "result": on_session_start.on_session_start(event, roots=roots)}
         if name == "Stop":
+            if os.environ.get(config.CHILD_SESSION_ENV):
+                return {"handled": name, "result": {"triggered": False, "reason": "recursion_guard"}}
             counters.bump_request(layer.GLOBAL, roots.get(layer.GLOBAL))  # MNG denominator (per turn)
             counters.bump_request(layer.PROJECT, proot)
             result = on_stop.on_stop(event, root=proot)

--- a/src/autoharness/hook/promoter.py
+++ b/src/autoharness/hook/promoter.py
@@ -22,12 +22,13 @@ validating admission (validate in-flight, persist only on allow) + POSIX atomic-
   exactly-once); on startup sweep orphan .tmp. On a crash, unprocessed intents stay in the durable queue
   and are retried next time; in the extreme of never running → zero land (fail-safe).
 
-ponytail: a single synchronous process already satisfies "serial single writer"; cross-process locking see mng open. LED watermark / create anchor get true values from CAP (Phase 4); v1 anchor uses the arg default 0. Whole-run clear, the tiny crash window (between land and clear) may re-append the LED — per-item idempotent watermark pending the intent-queue granularity being finalized (validate-store open).
+ponytail: a single synchronous process already satisfies "serial single writer"; cross-process locking see mng open. LED watermark still pends true values from CAP; the create anchor reads the layer request counter at land time (probation is fiction without a true anchor). Whole-run clear, the tiny crash window (between land and clear) may re-append the LED — per-item idempotent watermark pending the intent-queue granularity being finalized (validate-store open).
 """
 import hashlib
 
 from autoharness.lib import (
     atomic,
+    counters,
     intent_queue,
     layer,
     ledger,
@@ -94,7 +95,7 @@ def _land_files(level, name, files, root):
         atomic.write_text(p, files[rel])
 
 
-def _land(action, intent, body, level, name, root, anchor):
+def _land(action, intent, body, level, name, root):
     if action == "delete":
         evidence_ref = _materialize_evidence(level, name, intent.get("evidence"), root)
         ledger.append(level, name, _led(intent, evidence_ref), root)
@@ -104,11 +105,11 @@ def _land(action, intent, body, level, name, root, anchor):
     evidence_ref = _materialize_evidence(level, name, intent.get("evidence"), root)
     skill_store.write_body(level, name, body, root)
     if action == "create":
-        sidecar.create(level, name, anchor, root)
+        sidecar.create(level, name, counters.request_count(level, root), root)
     ledger.append(level, name, _led(intent, evidence_ref), root)
 
 
-def promote(intent, *, roots=None, repo_name=None, anchor=0):
+def promote(intent, *, roots=None, repo_name=None):
     roots = roots or {}
     action = intent.get("action")
     name = intent.get("name")
@@ -137,7 +138,7 @@ def promote(intent, *, roots=None, repo_name=None, anchor=0):
         return _reject(action, level, verdict["findings"])
 
     try:
-        _land(action, intent, body, level, name, root, anchor)
+        _land(action, intent, body, level, name, root)
     except ValueError as exc:
         return _reject(action, level, [("landing", str(exc))])
     return {"ok": True, "action": action, "level": level, "findings": []}
@@ -151,11 +152,11 @@ def sweep(roots=None):
     return removed
 
 
-def drain(run_id, *, roots=None, repo_name=None, anchor=0):
+def drain(run_id, *, roots=None, repo_name=None):
     roots = roots or {}
     sweep(roots)
     proot = roots.get(layer.PROJECT)
-    verdicts = [promote(i, roots=roots, repo_name=repo_name, anchor=anchor)
+    verdicts = [promote(i, roots=roots, repo_name=repo_name)
                 for i in intent_queue.read(run_id, proot)]
     intent_queue.clear(run_id, proot)
     return verdicts

--- a/src/autoharness/hook/spawn.py
+++ b/src/autoharness/hook/spawn.py
@@ -65,7 +65,7 @@ def _detached_spawn(argv, env, bundle):
 
 
 def run(window_text, run_id, *, roots, repo_name=None, agent=None, claude_bin=None,
-        spec_path=None, anchor=0, spawn_fn=None):
+        spec_path=None, spawn_fn=None):
     roots = roots or {}
     proot = roots.get(layer.PROJECT)
     spec = (spec_path or config.FORMAT_SPEC).read_text()
@@ -76,7 +76,7 @@ def run(window_text, run_id, *, roots, repo_name=None, agent=None, claude_bin=No
     env = child_env(run_id, proot)
     (spawn_fn or _detached_spawn)(argv, env, bundle)
 
-    return promoter.drain(run_id, roots=roots, repo_name=repo_name, anchor=anchor)
+    return promoter.drain(run_id, roots=roots, repo_name=repo_name)
 
 
 def main(argv=None):

--- a/src/autoharness/lib/lifecycle.py
+++ b/src/autoharness/lib/lifecycle.py
@@ -2,14 +2,14 @@
 
 mng.md: the survival criterion is **call rate** (call count / layer requests since creation), not
 wall-clock. Probation protects the new (denominator below the maturity threshold = live but not
-evicted, not counted against the cap); graduate-and-review (still calls==0 at full sample = archived
-on the spot); when the mature survivor pool exceeds the cap, archive the lowest by ascending rate.
+evicted, not counted against the cap). Capacity contention is the ONLY death: when the mature pool
+exceeds the cap, archive the lowest by ascending rate — zero-call symbols simply sit at the bottom.
 The decision only reads cumulative watermarks (sidecar calls + anchor, layer request count), so any
 repo's SessionStart reaches the same conclusion. on_session_start takes this list and runs
 skill_store.archive on each.
 
-ponytail: an absolute floor rule (a hard floor Y beyond graduate-review) and a rolling-window rate
-are deferred (open in mng.md).
+ponytail: an absolute floor rule (independent hard floor Y) and a rolling-window rate are
+deferred (open in mng.md).
 """
 
 
@@ -24,11 +24,7 @@ def evaluate(members, request_count, *, maturity, capacity):
         denom = max(0, request_count - m.get("anchor", 0))
         if denom < maturity:
             continue  # probation: live, not evicted, not counted against the cap
-        calls = m.get("calls", 0)
-        if calls == 0:
-            archive.add(m["name"])  # graduate-and-review: given enough chances, still zero calls
-            continue
-        survivors.append((_rate(calls, denom), m["name"]))
+        survivors.append((_rate(m.get("calls", 0), denom), m["name"]))
     if len(survivors) > capacity:
         survivors.sort(key=lambda rn: rn)  # ascending rate, ties broken stably by name
         archive.update(name for _, name in survivors[: len(survivors) - capacity])

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -54,6 +54,17 @@ def test_subagent_stop_is_ignored(tmp_path):
     assert dispatch.dispatch({"hook_event_name": "SubagentStop"}, roots=_roots(tmp_path))["ignored"] is True
 
 
+def test_child_session_stop_bumps_nothing(tmp_path, monkeypatch):
+    # a reflector child's turns must not inflate MNG denominators (guard runs before the bump)
+    monkeypatch.setenv(config.CHILD_SESSION_ENV, "1")
+    roots = _roots(tmp_path)
+    out = dispatch.dispatch({"hook_event_name": "Stop", "session_id": "s1"},
+                            roots=roots, reflect=lambda *a: None)
+    assert out["result"]["triggered"] is False
+    assert counters.request_count(layer.PROJECT, roots[layer.PROJECT]) == 0
+    assert counters.request_count(layer.GLOBAL, roots[layer.GLOBAL]) == 0
+
+
 def test_stop_bumps_both_layer_denominators(tmp_path):
     roots = _roots(tmp_path)
     dispatch.dispatch({"hook_event_name": "Stop", "session_id": "s1"},

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -11,9 +11,15 @@ def test_probation_never_archived():
     assert out == []
 
 
-def test_graduation_audit_zero_calls_archived():
-    # denom = 20 ≥ maturity 10, calls 0 → archived on graduation
+def test_mature_zero_calls_survives_without_capacity_pressure():
+    # denom = 20 ≥ maturity 10, calls 0, pool under cap → capacity contention is the only death
     out = lifecycle.evaluate([_m("idle", 0)], request_count=20, maturity=10, capacity=5)
+    assert out == []
+
+
+def test_mature_zero_calls_evicted_first_under_capacity_pressure():
+    members = [_m("idle", 0), _m("used", 30)]
+    out = lifecycle.evaluate(members, request_count=100, maturity=10, capacity=1)
     assert out == ["idle"]
 
 
@@ -30,10 +36,10 @@ def test_high_rate_kept_under_capacity():
 
 
 def test_denominator_grows_with_requests():
-    # same symbol: probation at low request count, auditable once denom passes maturity
-    m = [_m("x", 0, anchor=0)]
-    assert lifecycle.evaluate(m, request_count=9, maturity=10, capacity=5) == []      # denom 9 < 10
-    assert lifecycle.evaluate(m, request_count=10, maturity=10, capacity=5) == ["x"]  # denom 10 ≥ 10
+    # same symbol: probation at low request count, joins the mature pool once denom passes maturity
+    m = [_m("x", 0, anchor=0), _m("y", 8, anchor=0)]
+    assert lifecycle.evaluate(m, request_count=9, maturity=10, capacity=1) == []       # denom 9 < 10: both probation
+    assert lifecycle.evaluate(m, request_count=10, maturity=10, capacity=1) == ["x"]   # mature pool of 2 over cap 1, lowest rate out
 
 
 def test_anchor_offsets_denominator():

--- a/tests/test_lifecycle_e2e.py
+++ b/tests/test_lifecycle_e2e.py
@@ -73,8 +73,11 @@ def test_full_skill_lifecycle_through_dispatch(tmp_path, capsys):
     print(f"[use]    learned calls={sidecar.read('project', 'learned', proot)['calls']}")
 
     # BEAT 3 — compete: a weak unused peer; MNG recompute (SessionStart) archives the loser.
+    # learned landed with a real anchor (=2), so two more turns first to graduate it out of probation.
+    for _ in range(2):
+        dispatch.dispatch(stop, roots=roots, reflect=lambda *a: None)
     skill_store.write_body("project", "weak", WEAK, proot)
-    sidecar.create("project", "weak", anchor=0, root=proot)              # mature (denom 2), zero calls
+    sidecar.create("project", "weak", anchor=0, root=proot)              # mature (denom 4), zero calls
     req = counters.request_count(layer.PROJECT, proot)
     mat = config.MATURITY_THRESHOLD[layer.PROJECT]
     for name in ("learned", "weak"):                                    # monitor MNG numerator/denominator

--- a/tests/test_on_session_start.py
+++ b/tests/test_on_session_start.py
@@ -30,7 +30,7 @@ def test_archives_idle_and_overflow_keeps_strong_and_probation(tmp_path, monkeyp
     _small_knobs(monkeypatch, cap_project=1)
     roots = _roots(tmp_path)
     _set_requests(roots, "project", 100)
-    _seed(roots, "idle", calls=0)             # mature, zero calls → graduation audit
+    _seed(roots, "idle", calls=0)             # mature, rate 0 → bottom of the capacity race
     _seed(roots, "weak", calls=5)             # rate .05, loses capacity race
     _seed(roots, "strong", calls=80)          # rate .8, top of pool → kept
     _seed(roots, "baby", calls=1, anchor=95)  # denom 5 < 10 → probation → survives
@@ -59,7 +59,7 @@ def test_native_skill_never_archived(tmp_path, monkeypatch):
 
 
 def test_verdict_reads_accumulated_state_same_across_repos(tmp_path, monkeypatch):
-    _small_knobs(monkeypatch)
+    _small_knobs(monkeypatch, cap_project=1)
     # two repos seeded identically → identical verdict (reads water level, not session)
     def run(sub):
         roots = _roots(tmp_path / sub)
@@ -72,9 +72,19 @@ def test_verdict_reads_accumulated_state_same_across_repos(tmp_path, monkeypatch
 
 
 def test_second_run_is_noop_after_archival(tmp_path, monkeypatch):
-    _small_knobs(monkeypatch)
+    _small_knobs(monkeypatch, cap_project=1)
     roots = _roots(tmp_path)
     _set_requests(roots, "project", 100)
     _seed(roots, "idle", calls=0)
+    _seed(roots, "used", calls=50)
     assert on_session_start.on_session_start(roots=roots)["archived"]["project"] == ["idle"]
     assert on_session_start.on_session_start(roots=roots)["archived"]["project"] == []
+
+
+def test_mature_zero_calls_survives_without_capacity_pressure(tmp_path, monkeypatch):
+    _small_knobs(monkeypatch, cap_project=5)
+    roots = _roots(tmp_path)
+    _set_requests(roots, "project", 100)
+    _seed(roots, "idle", calls=0)  # mature, rate 0 — but pool under cap → survives
+    assert on_session_start.on_session_start(roots=roots)["archived"]["project"] == []
+    assert skill_store.exists("project", "idle", roots["project"])

--- a/tests/test_promoter.py
+++ b/tests/test_promoter.py
@@ -1,7 +1,7 @@
 import json
 
 from autoharness.hook import promoter
-from autoharness.lib import intent_queue, layer, ledger, sidecar, skill_store
+from autoharness.lib import counters, intent_queue, layer, ledger, sidecar, skill_store
 
 GOOD_BODY = "---\nname: foo\ndescription: Formats dates as ISO.\n---\n# Foo\nUse strftime.\n"
 
@@ -21,12 +21,14 @@ def _families(v):
 
 def test_create_lands_body_sidecar_led(tmp_path):
     roots = _roots(tmp_path)
-    v = promoter.promote(_create(), roots=roots, anchor=7)
+    for _ in range(7):
+        counters.bump_request("project", roots["project"])
+    v = promoter.promote(_create(), roots=roots)
     assert v["ok"] and v["level"] == "project"
     root = roots["project"]
     assert skill_store.read_body("project", "foo", root) == GOOD_BODY
     assert sidecar.is_agent_created("project", "foo", root)
-    assert sidecar.read("project", "foo", root)["anchor"] == 7
+    assert sidecar.read("project", "foo", root)["anchor"] == 7  # anchor = layer request count at land time
     led = ledger.read("project", "foo", root)
     assert len(led) == 1 and led[0]["action"] == "create" and led[0]["reason"]
 


### PR DESCRIPTION
## What

The first live self-generated skill (`sandbox-test-reflector`) survived 10 seconds: it landed at 09:22:14 and the next SessionStart archived it at 09:22:24. Two compounding defects in the rate machinery, plus one adjacent counting bug:

1. **Real anchor at land time.** Sidecars were created with the v1 default `anchor=0`, so a newborn's denominator = the full layer request count (116) ≥ maturity (20) — born mature, probation never applied. The promoter now reads the layer request counter when landing a `create` and writes it as the anchor; the threaded `anchor` parameter is removed from `promote`/`drain`/`spawn.run`.
2. **Graduation audit removed.** "Mature with rate≈0 → archive on the spot" was a fixed death line that ignored capacity pressure, contradicting the design's own invariant (*evicted iff least useful AND over capacity*) — it killed with the pool at 1 of 50. Capacity contention is now the only death; zero-call symbols just sit at the bottom of the race. The maturity threshold degrades from a death exam to "when you start counting against the cap".
3. **Recursion guard before the bump.** `dispatch` bumped both layer request counters on every Stop *before* the child-session guard ran, so reflector child turns inflated every symbol's denominator. The guard now short-circuits first.

## Tests

- `test_mature_zero_calls_survives_without_capacity_pressure` (lifecycle + session-start levels)
- `test_mature_zero_calls_evicted_first_under_capacity_pressure`
- `test_create_lands_body_sidecar_led` now derives the anchor from the real counter
- `test_child_session_stop_bumps_nothing`
- e2e lifecycle adapted: learned now graduates through real turns before the capacity race
- 250 passed, ruff clean

Plugin version 0.2.6 → 0.2.7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)