### PR TITLE
chore: raise maturity-threshold defaults (project 20→100, global 50→300)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autoharness",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Per-symbol maintenance optimizer for an agent's skill layer — learns skills from real runs and keeps them by adherence in use, not by an offline eval score.",
   "author": { "name": "Tigerless Labs" },
   "homepage": "https://github.com/tigerless-labs/autoharness",

--- a/src/autoharness/config.py
+++ b/src/autoharness/config.py
@@ -33,8 +33,8 @@ STAGE_MAX_FILE_BYTES = 64_000
 STAGE_MAX_FILES_TOTAL_BYTES = 256_000
 
 # maturity threshold (denominator gate to graduate out of probation) / capacity cap, set per layer, independently tunable. global has a larger blast radius -> more conservative (smaller capacity).
-MATURITY_THRESHOLD = {layer.GLOBAL: _int_env("AUTOHARNESS_MATURITY_GLOBAL", 50),
-                      layer.PROJECT: _int_env("AUTOHARNESS_MATURITY_PROJECT", 20)}
+MATURITY_THRESHOLD = {layer.GLOBAL: _int_env("AUTOHARNESS_MATURITY_GLOBAL", 300),
+                      layer.PROJECT: _int_env("AUTOHARNESS_MATURITY_PROJECT", 100)}
 CAPACITY = {layer.GLOBAL: _int_env("AUTOHARNESS_CAPACITY_GLOBAL", 20),
             layer.PROJECT: _int_env("AUTOHARNESS_CAPACITY_PROJECT", 50)}
 


### PR DESCRIPTION
20 turns ≈ one session — too short for a niche skill to meet its trigger scenario. Post-#60 maturity only gates entry into the capacity race, so longer probation is free. Global gets a longer window since its denominator accrues across all installed repos. Both remain env-overridable (`AUTOHARNESS_MATURITY_*`); empirical calibration still open in mng.md.

Plugin version 0.2.7 → 0.2.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)