### PR TITLE
feat: feed the reflector a prior-context digest, Hermes-style

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autoharness",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "Per-symbol maintenance optimizer for an agent's skill layer — learns skills from real runs and keeps them by adherence in use, not by an offline eval score.",
   "author": { "name": "Tigerless Labs" },
   "homepage": "https://github.com/tigerless-labs/autoharness",

--- a/agents/reflector.md
+++ b/agents/reflector.md
@@ -11,11 +11,12 @@ You only ever **propose**. You have no Write, Edit, or Bash. Your single write f
 
 ## What you are given (do not go fetch it)
 
-Your input already contains three things; read them, don't search for them:
+Your input already contains these things; read them, don't search for them:
 
-1. A redacted raw slice of the host transcript (JSONL events) since the last reflection — the episode trace. It contains tool results, meta records, and truncation marks verbatim; read past the noise to the user/assistant story.
-2. A description index of every existing skill across both layers (`global` and `project`), as `name [layer]: description`.
-3. The authoring + format spec the skill must satisfy. Write to **this** spec — do not infer format from existing skills.
+1. Possibly a prior-context digest: a compressed run of the exchanges before the episode window (text and tool names only, tool outputs omitted). Background for understanding where the episode started — never quote it as evidence.
+2. A redacted raw slice of the host transcript (JSONL events) since the last reflection — the episode trace. It contains tool results, meta records, and truncation marks verbatim; read past the noise to the user/assistant story.
+3. A description index of every existing skill across both layers (`global` and `project`), as `name [layer]: description`.
+4. The authoring + format spec the skill must satisfy. Write to **this** spec — do not infer format from existing skills.
 
 Use `Read` / `Grep` / `Glob` only to look closer at an *existing* skill's body when compare-first flags it as a candidate. The trace and the index are injected; never reconstruct them with tools.
 
@@ -56,4 +57,4 @@ Tool arguments:
 - `action`: `create` | `update` | `patch` | `delete`. Action follows from the rung you chose — reach for `patch` to amend, `update` when adding subfiles or rewriting, `create` when nothing existing fits.
 - `create` / `update` carry the **full** `SKILL.md` body (satisfying the format spec), plus optional `files`. `patch` carries `old_string` → `new_string` (the `old_string` must match the live body uniquely). `delete` carries no body.
 - `create` also carries `level`. Choose by what the lesson is *about*: repo-specific (this codebase, its paths, stack, conventions) → `project`; a user preference (style, tone, workflow) or a general technique → `global`; unsure → `project`. A `global` skill loads in every project, so it and its subfiles must contain **no** repo-local identifiers (absolute paths, this repo's name) — if they would, make it `project`.
-- `reason` and `evidence` are required on every intent. `evidence` must be a verbatim slice from the window, not invented — the promoter materializes it into the skill's `references/` as permanent provenance, so keep it the real excerpt.
+- `reason` and `evidence` are required on every intent. `evidence` must be a verbatim slice from the raw episode window (never from the digest), not invented — the promoter materializes it into the skill's `references/` as permanent provenance, so keep it the real excerpt.

--- a/src/autoharness/config.py
+++ b/src/autoharness/config.py
@@ -24,6 +24,9 @@ REFLECT_EVERY_N = _int_env("AUTOHARNESS_REFLECT_EVERY_N", 3)  # trigger cadence;
 # and per handoff window (tail kept) — bound tool dumps / base64 away from the child context.
 CAPTURE_MAX_RECORD_BYTES = 4_000
 CAPTURE_MAX_WINDOW_BYTES = 200_000
+DIGEST_EXCHANGES = _int_env("AUTOHARNESS_DIGEST_EXCHANGES", 20)  # prior-context digest: exchanges before the window
+DIGEST_MAX_RECORD_CHARS = 200
+DIGEST_MAX_BYTES = 20_000
 
 STAGE_MAX_BODY_BYTES = 100_000  # ponytail: placeholder, SKILL.md body cap; for instant feedback on stage_skill args
 

--- a/src/autoharness/hook/capture.py
+++ b/src/autoharness/hook/capture.py
@@ -9,6 +9,7 @@ child context), pass the egress red line (redact), and hand the text plus the ne
 the caller. **Never write back to the host raw log** (it is not ours). A missing / stale / negative
 watermark (compaction rewrote the file) fails safe to a full re-read bounded by the window cap.
 """
+import json
 from pathlib import Path
 
 from autoharness import config
@@ -42,3 +43,58 @@ def window(transcript_path, offset=0, *, max_record_bytes=None, max_window_bytes
             break
         kept.append(line)
     return redact.redact("\n".join(reversed(kept)), rules_path), new_offset
+
+
+def _digest_record(line, max_chars):
+    record = json.loads(line)
+    if record.get("type") not in ("user", "assistant"):
+        return None
+    role = record["type"]
+    content = record["message"]["content"]
+    if isinstance(content, str):
+        parts = [content]
+    else:
+        parts = []
+        for block in content:
+            kind = block.get("type")
+            if kind == "text" and block.get("text"):
+                parts.append(block["text"])
+            elif kind == "tool_use":
+                parts.append(f"[tool: {block.get('name', '?')}]")
+    if not parts:
+        return None
+    text = " ".join(p.strip() for p in parts if p.strip())
+    if len(text) > max_chars:
+        text = text[:max_chars] + TRUNCATION_MARK
+    return role, text
+
+
+def digest(transcript_path, end_offset, *, max_exchanges=None, max_record_chars=None,
+           max_digest_bytes=None, rules_path=None):
+    exchanges = max_exchanges or config.DIGEST_EXCHANGES
+    record_chars = max_record_chars or config.DIGEST_MAX_RECORD_CHARS
+    digest_cap = max_digest_bytes or config.DIGEST_MAX_BYTES
+    path = Path(transcript_path)
+    if not path.exists() or end_offset <= 0:
+        return ""
+    data = path.read_bytes()[:end_offset]
+    kept, total, users_seen = [], 0, 0
+    for line in reversed(data.decode("utf-8", errors="replace").splitlines()):
+        try:
+            entry = _digest_record(line, record_chars)
+        except (json.JSONDecodeError, KeyError, TypeError, AttributeError):
+            continue
+        if entry is None:
+            continue
+        role, text = entry
+        rendered = f"{role}: {text}"
+        total += len(rendered) + 1
+        if total > digest_cap:
+            kept.append(TRUNCATION_MARK)
+            break
+        kept.append(rendered)
+        if role == "user":
+            users_seen += 1
+            if users_seen >= exchanges:
+                break
+    return redact.redact("\n".join(reversed(kept)), rules_path) if kept else ""

--- a/src/autoharness/hook/spawn.py
+++ b/src/autoharness/hook/spawn.py
@@ -35,9 +35,14 @@ def description_index(roots=None):
     return "\n".join(lines) if lines else "(no live skills yet)"
 
 
-def build_bundle(window, index, spec):
+def build_bundle(window, index, spec, digest=""):
+    preamble = (
+        "# Prior context digest (older exchanges, tool outputs omitted — background only,"
+        " never an evidence source)\n\n" + digest + "\n\n"
+    ) if digest else ""
     return (
-        "# Episode window (redacted)\n\n" + window
+        preamble
+        + "# Episode window (redacted)\n\n" + window
         + "\n\n# Existing skills (compare-first: dedupe / patch / where)\n\n" + index
         + "\n\n# Authoring + format spec (write to satisfy this)\n\n" + spec + "\n"
     )
@@ -65,11 +70,11 @@ def _detached_spawn(argv, env, bundle):
 
 
 def run(window_text, run_id, *, roots, repo_name=None, agent=None, claude_bin=None,
-        spec_path=None, spawn_fn=None):
+        spec_path=None, digest="", spawn_fn=None):
     roots = roots or {}
     proot = roots.get(layer.PROJECT)
     spec = (spec_path or config.FORMAT_SPEC).read_text()
-    bundle = build_bundle(window_text, description_index(roots), spec)
+    bundle = build_bundle(window_text, description_index(roots), spec, digest=digest)
 
     argv = build_command(agent=agent or config.REFLECTOR_AGENT,
                          claude_bin=claude_bin or config.CLAUDE_BIN)
@@ -84,7 +89,8 @@ def main(argv=None):
     roots = {layer.PROJECT: Path(proot), layer.GLOBAL: Path(groot)}
     offset = counters.session_offset(session_id, roots[layer.PROJECT])
     window_text, new_offset = capture.window(transcript_path, offset)
-    result = run(window_text, run_id, roots=roots)
+    result = run(window_text, run_id, roots=roots,
+                 digest=capture.digest(transcript_path, offset))
     counters.write_session_offset(session_id, new_offset, roots[layer.PROJECT])
     return result
 

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -82,3 +82,86 @@ def test_window_never_mutates_source(tmp_path):
 
 def test_window_missing_transcript_empty(tmp_path):
     assert capture.window(tmp_path / "nope.jsonl") == ("", 0)
+
+
+def _assistant(text=None, tool=None):
+    content = []
+    if text:
+        content.append({"type": "text", "text": text})
+    if tool:
+        content.append({"type": "tool_use", "name": tool, "input": {"command": "secret-args"}})
+    return {"type": "assistant", "message": {"role": "assistant", "content": content}}
+
+
+def _tool_result(output):
+    return {"type": "user", "message": {"role": "user", "content": [
+        {"type": "tool_result", "content": output}]}}
+
+
+def test_digest_keeps_text_and_tool_names_drops_outputs(tmp_path):
+    t = tmp_path / "transcript.jsonl"
+    _write_transcript(t, [
+        _record(0, text="fix the login bug"),
+        _assistant(text="Looking at auth.py", tool="Bash"),
+        _tool_result("HUGE-TOOL-OUTPUT-" * 50),
+        _assistant(text="Fixed by adding a null check."),
+    ])
+    end = t.stat().st_size
+    d = capture.digest(t, end)
+    assert "fix the login bug" in d
+    assert "Looking at auth.py" in d
+    assert "Bash" in d                      # tool name survives
+    assert "HUGE-TOOL-OUTPUT" not in d      # tool result content dropped
+    assert "secret-args" not in d           # tool input dropped too
+
+
+def test_digest_only_covers_bytes_before_offset(tmp_path):
+    t = tmp_path / "transcript.jsonl"
+    _write_transcript(t, [_record(0, text="early context")])
+    end = t.stat().st_size
+    with t.open("a") as f:
+        f.write(json.dumps(_record(1, text="fresh window")) + "\n")
+    d = capture.digest(t, end)
+    assert "early context" in d
+    assert "fresh window" not in d
+    assert capture.digest(t, 0) == ""       # nothing before offset zero
+
+
+def test_digest_keeps_only_last_n_exchanges(tmp_path):
+    t = tmp_path / "transcript.jsonl"
+    records = []
+    for i in range(30):
+        records.append(_record(i, text=f"question-{i}"))
+        records.append(_assistant(text=f"answer-{i}"))
+    _write_transcript(t, records)
+    d = capture.digest(t, t.stat().st_size, max_exchanges=5)
+    assert "question-29" in d and "answer-29" in d
+    assert "question-24" not in d and "question-0" not in d
+
+
+def test_digest_clips_records_and_total(tmp_path):
+    t = tmp_path / "transcript.jsonl"
+    _write_transcript(t, [_record(0, text="y" * 5000), _record(1, text="tail-mark")])
+    d = capture.digest(t, t.stat().st_size, max_record_chars=100)
+    assert "tail-mark" in d
+    assert "y" * 200 not in d
+    big = tmp_path / "big.jsonl"
+    _write_transcript(big, [_record(i, text=f"m{i}-" + "z" * 150) for i in range(100)])
+    d2 = capture.digest(big, big.stat().st_size, max_digest_bytes=500)
+    assert len(d2) < 1200
+    assert "m99-" in d2                      # tail kept when capped
+
+
+def test_digest_redacts_and_survives_garbage(tmp_path):
+    t = tmp_path / "transcript.jsonl"
+    t.write_text("NOT-JSON{{{\n"
+                 + json.dumps(_record(0, text="key AKIAIOSFODNN7EXAMPLE end")) + "\n"
+                 + '{"type": "assistant", "message": null}\n')
+    d = capture.digest(t, t.stat().st_size)
+    assert "AKIAIOSFODNN7EXAMPLE" not in d
+    assert "[REDACTED:" in d
+    assert "NOT-JSON" not in d               # garbage lines skipped, no crash
+
+
+def test_digest_missing_transcript_empty(tmp_path):
+    assert capture.digest(tmp_path / "nope.jsonl", 100) == ""

--- a/tests/test_spawn.py
+++ b/tests/test_spawn.py
@@ -15,11 +15,13 @@ def _roots(tmp_path):
 
 def test_main_parses_argv_and_runs(tmp_path, monkeypatch):
     monkeypatch.setattr(spawn.capture, "window", lambda tp, off, **k: (f"WIN[{tp}|{off}]", 42))
+    monkeypatch.setattr(spawn.capture, "digest", lambda tp, off, **k: f"DIG[{tp}|{off}]")
     seen = {}
     monkeypatch.setattr(spawn, "run",
-                        lambda w, rid, **k: seen.update(w=w, rid=rid, roots=k["roots"]))
+                        lambda w, rid, **k: seen.update(w=w, rid=rid, roots=k["roots"], digest=k["digest"]))
     spawn.main(["/t.jsonl", "sess-1", "run-9", str(tmp_path / "p"), str(tmp_path / "g")])
     assert seen["w"] == "WIN[/t.jsonl|0]"
+    assert seen["digest"] == "DIG[/t.jsonl|0]"  # digest covers the bytes before the window offset
     assert seen["rid"] == "run-9"
     assert seen["roots"][layer.PROJECT] == tmp_path / "p"
     assert seen["roots"][layer.GLOBAL] == tmp_path / "g"
@@ -28,6 +30,7 @@ def test_main_parses_argv_and_runs(tmp_path, monkeypatch):
 
 def test_main_offset_advances_only_after_run(tmp_path, monkeypatch):
     monkeypatch.setattr(spawn.capture, "window", lambda tp, off, **k: ("W", 99))
+    monkeypatch.setattr(spawn.capture, "digest", lambda tp, off, **k: "")
     monkeypatch.setattr(spawn, "run", lambda *a, **k: (_ for _ in ()).throw(RuntimeError("boom")))
     counters.write_session_offset("sess-2", 7, tmp_path / "p")
     try:
@@ -62,6 +65,13 @@ def test_description_index_empty_is_placeholder(tmp_path):
 def test_build_bundle_injects_three_pieces():
     b = spawn.build_bundle("WINDOW_MARK", "INDEX_MARK", "SPEC_MARK")
     assert "WINDOW_MARK" in b and "INDEX_MARK" in b and "SPEC_MARK" in b
+
+
+def test_build_bundle_prepends_digest_when_present():
+    b = spawn.build_bundle("WINDOW_MARK", "INDEX_MARK", "SPEC_MARK", digest="DIGEST_MARK")
+    assert "DIGEST_MARK" in b
+    assert b.index("DIGEST_MARK") < b.index("WINDOW_MARK")  # chronological: prior context first
+    assert "DIGEST_MARK" not in spawn.build_bundle("W", "I", "S", digest="")  # empty -> no section
 
 
 def test_build_command_carries_agent_and_print():


### PR DESCRIPTION
## What

Prepends a deterministic **prior-context digest** to every reflector bundle: the ~20 exchanges (config `AUTOHARNESS_DIGEST_EXCHANGES`) before the raw episode window, with per-record clipped user/assistant text, tool calls reduced to `[tool: Name]`, and **tool outputs dropped entirely**. No LLM — Hermes' `_digest_history` shape.

## Why

The 3-turn zero-overlap window cuts long episodes mid-arc — the reflector sees the fix but not the problem. This replaces the previously-decided carry-forward design (reflector-judged closure + persisted residual windows): the digest is stateless, recomputed from the transcript bytes before the watermark each time, and needs no closure verdict channel.

## Boundaries

- Digest is background only: the reflector prompt now pins `evidence` to the raw window, never the digest.
- Fail-safe per record: garbage lines skipped; missing transcript or zero offset → empty digest; total and per-record byte caps; passes the same egress redaction as the window.

## Tests

6 new digest cases (tool-output exclusion, offset boundary, last-N exchanges, clipping/caps, redaction + garbage survival, missing file) + bundle/main wiring; smoke-tested against a real session transcript. 257 passed, ruff clean.

Plugin version 0.2.8 → 0.2.9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)