### PR TITLE
feat: remove_file — single-subfile deletion channel + evidence-slice intent gate

### DIFF
--- a/agents/reflector.md
+++ b/agents/reflector.md
@@ -48,13 +48,15 @@ A skill is a folder. Besides the SKILL.md body, `create`/`update` may carry `fil
 
 Every subfile you carry must be referenced by its relative path somewhere in the SKILL.md body (a one-line pointer is enough) — the promoter rejects unpointed subfiles. Keep the SKILL.md itself tight; move bulk detail into `references/`.
 
+To drop a subfile that is stale or wrong, stage a `remove_file` intent carrying its relative `path`. The live SKILL.md must no longer reference the path, so `patch` the pointer out first — stage both intents in the same run, they land in order. `references/evidence-*` files are promoter-owned provenance: you can neither write nor remove them.
+
 ## Emitting intents (call the `stage_skill` tool)
 
 **You act by calling the `stage_skill` tool — not by writing text.** Do not output the SKILL.md, the action, or the fields as prose in your reply; a textual description creates nothing. The *only* thing that records a change is an actual invocation of the `stage_skill` tool. Stage one intent per distinct lesson — several lessons, several calls. After they return, briefly confirm what you staged.
 
 Tool arguments:
 
-- `action`: `create` | `update` | `patch` | `delete`. Action follows from the rung you chose — reach for `patch` to amend, `update` when adding subfiles or rewriting, `create` when nothing existing fits.
-- `create` / `update` carry the **full** `SKILL.md` body (satisfying the format spec), plus optional `files`. `patch` carries `old_string` → `new_string` (the `old_string` must match the live body uniquely). `delete` carries no body.
+- `action`: `create` | `update` | `patch` | `remove_file` | `delete`. Action follows from the rung you chose — reach for `patch` to amend, `update` when adding subfiles or rewriting, `remove_file` to drop one subfile, `create` when nothing existing fits.
+- `create` / `update` carry the **full** `SKILL.md` body (satisfying the format spec), plus optional `files`. `patch` carries `old_string` → `new_string` (the `old_string` must match the live body uniquely). `remove_file` carries `path`. `delete` carries no body.
 - `create` also carries `level`. Choose by what the lesson is *about*: repo-specific (this codebase, its paths, stack, conventions) → `project`; a user preference (style, tone, workflow) or a general technique → `global`; unsure → `project`. A `global` skill loads in every project, so it and its subfiles must contain **no** repo-local identifiers (absolute paths, this repo's name) — if they would, make it `project`.
 - `reason` and `evidence` are required on every intent. `evidence` must be a verbatim slice from the raw episode window (never from the digest), not invented — the promoter materializes it into the skill's `references/` as permanent provenance, so keep it the real excerpt.

--- a/src/autoharness/hook/promoter.py
+++ b/src/autoharness/hook/promoter.py
@@ -17,7 +17,9 @@ validating admission (validate in-flight, persist only on allow) + POSIX atomic-
   point: recall only reads SKILL.md, so a reader never sees it point at an unlanded subfile) → create
   stamps the sidecar created_by:agent → append the intent's own LED with evidence as the slice's
   relative path. delete = materialize evidence + LED retirement + archive move-out (whole-dir
-  os.replace carries the slices along). Reject = zero writes, no stamp, no ledger.
+  os.replace carries the slices along). remove_file = drop one subfile (path re-gated + escape-checked;
+  rejected while the live SKILL.md still references it; missing target = no-op, so crash replays stay
+  idempotent) + evidence + LED with the removed path. Reject = zero writes, no stamp, no ledger.
 - Drain: read queue → promote one by one → clear at the end (at-least-once + atomic land = effectively
   exactly-once); on startup sweep orphan .tmp. On a crash, unprocessed intents stay in the durable queue
   and are retried next time; in the extreme of never running → zero land (fail-safe).
@@ -38,7 +40,7 @@ from autoharness.lib import (
     validate,
 )
 
-_MODIFY = ("update", "patch", "delete")
+_MODIFY = ("update", "patch", "remove_file", "delete")
 
 
 def _reject(action, level, findings):
@@ -63,20 +65,23 @@ def _shape(intent, level, root):
         if live is None:
             raise ValueError("patch target has no live body")
         return skill_store.apply_delta(live, intent["old_string"], intent["new_string"])
-    if action == "delete":
+    if action in ("remove_file", "delete"):
         return None
     raise ValueError(f"unknown action: {action!r}")
 
 
 def _led(intent, evidence_ref):
-    return {"action": intent.get("action"),
-            "reason": intent.get("reason"),
-            "evidence": evidence_ref}
+    entry = {"action": intent.get("action"),
+             "reason": intent.get("reason"),
+             "evidence": evidence_ref}
+    if intent.get("path"):
+        entry["path"] = intent["path"]
+    return entry
 
 
 def _materialize_evidence(level, name, evidence, root):
     text = redact.redact(evidence)
-    rel = f"references/evidence-{hashlib.sha256(text.encode('utf-8')).hexdigest()[:8]}.md"
+    rel = f"{layer.EVIDENCE_PREFIX}{hashlib.sha256(text.encode('utf-8')).hexdigest()[:8]}.md"
     p = layer.subfile_path(level, name, rel, root)
     if not p.exists():
         atomic.write_text(p, text)
@@ -95,11 +100,28 @@ def _land_files(level, name, files, root):
         atomic.write_text(p, files[rel])
 
 
+def _remove_subfile(level, name, rel, root):
+    p = layer.subfile_path(level, name, rel, root)
+    sdir = layer.symbol_dir(level, name, root).resolve()
+    if not p.resolve().is_relative_to(sdir):
+        raise ValueError(f"subfile escapes the skill dir: {rel}")
+    live = skill_store.read_body(level, name, root) or ""
+    if rel in live:
+        raise ValueError(f"{rel} is still referenced by the live SKILL.md (patch the pointer out first)")
+    if p.is_file():
+        p.unlink()
+
+
 def _land(action, intent, body, level, name, root):
     if action == "delete":
         evidence_ref = _materialize_evidence(level, name, intent.get("evidence"), root)
         ledger.append(level, name, _led(intent, evidence_ref), root)
         skill_store.archive(level, name, root)
+        return
+    if action == "remove_file":
+        _remove_subfile(level, name, intent["path"], root)
+        evidence_ref = _materialize_evidence(level, name, intent.get("evidence"), root)
+        ledger.append(level, name, _led(intent, evidence_ref), root)
         return
     _land_files(level, name, intent.get("files"), root)
     evidence_ref = _materialize_evidence(level, name, intent.get("evidence"), root)

--- a/src/autoharness/lib/format_spec.md
+++ b/src/autoharness/lib/format_spec.md
@@ -45,7 +45,12 @@ rejected. Conversely, a whitelisted-directory path referenced in the body must b
 same intent or already live in the skill folder.
 
 `references/evidence-*.md` files are promoter-materialized provenance (the ledger points at
-them); they are never authored in an intent and are exempt from the pointer rule.
+them); they are never authored in an intent and are exempt from the pointer rule. Intents can
+neither carry them in `files` nor target them with `remove_file`.
+
+A subfile that is no longer needed is dropped with the `remove_file` action (one relative path
+per intent, same path rules). The live `SKILL.md` must no longer reference the path — patch the
+pointer out first; both intents can ride the same run, they land in order.
 
 ## Content completeness
 

--- a/src/autoharness/lib/layer.py
+++ b/src/autoharness/lib/layer.py
@@ -81,6 +81,7 @@ def symbol_dir(layer, name, root=None):
 
 
 SUBFILE_DIRS = ("scripts", "templates", "assets", "references")
+EVIDENCE_PREFIX = "references/evidence-"
 
 
 def check_subfile(rel):

--- a/src/autoharness/lib/validate.py
+++ b/src/autoharness/lib/validate.py
@@ -8,14 +8,16 @@ verdict {ok, findings:[(family, detail)]}; non-empty findings = reject. create i
 When base_dir is given, the #416 "referenced .py syntax" check is added (a referenced, existing .py
 must parse), plus the subfile-reference check: a whitelisted-dir path mentioned in the body must be
 carried in the intent's `files` or already live under base_dir. target_is_agent_created is passed in
-by promoter after reading the sidecar; on create it is None and exempt. When body=None (a delete's
-shaped result = removal, no body), the four body-dependent classes (safety/structure/complete/global)
-are skipped, leaving only the LED + self-produced checks.
+by promoter after reading the sidecar; on create it is None and exempt. When body=None (delete /
+remove_file shape to no body change), the four body-dependent classes (safety/structure/complete/
+global) are skipped, leaving the LED + self-produced checks — remove_file adds its path gate
+(check_remove_path: subfile whitelist + evidence-slice deny).
 
 folder-skill `files` (relative path → content) gets its own `files` family (check_files: shape, path
 gate via layer.check_subfile, count/size caps) + the pointer rule (every carried subfile must be
 referenced in the body) + per-subfile safety and global scans — otherwise subfiles would be a trivial
-bypass of both gates. Promoter-materialized `references/evidence-*.md` never travel in `files`.
+bypass of both gates. Promoter-materialized `references/evidence-*` slices are off-limits to intents
+in both directions: carrying one in `files` and removing one via remove_file are rejected.
 """
 import ast
 import re
@@ -28,7 +30,7 @@ _PLACEHOLDER = re.compile(r"\b(TODO|FIXME|XXX):|<[A-Z][A-Z_]{2,}>")
 _ABS_PATH = re.compile(r"(?:/home/|/Users/|/root/)[^\s`)\]]+|[A-Za-z]:\\[^\s`)\]]+")
 _PY_REF = re.compile(r"[\w./-]+\.py")
 _SUBFILE_REF = re.compile(r"\b(?:{})/[A-Za-z0-9._/-]+".format("|".join(layer.SUBFILE_DIRS)))
-_MODIFY = ("update", "patch", "delete")
+_MODIFY = ("update", "patch", "remove_file", "delete")
 
 
 def _frontmatter(body):
@@ -43,6 +45,20 @@ def _frontmatter(body):
         key, value = line.split(":", 1)
         fm[key.strip()] = value.strip().strip('"').strip("'")
     return fm
+
+
+def _evidence_slice_denied(rel):
+    if rel.startswith(layer.EVIDENCE_PREFIX):
+        return [("files", f"{rel}: promoter-materialized evidence slices are off-limits to intents")]
+    return []
+
+
+def check_remove_path(rel):
+    try:
+        layer.check_subfile(rel)
+    except ValueError as exc:
+        return [("files", str(exc))]
+    return _evidence_slice_denied(rel)
 
 
 def check_files(files):
@@ -63,6 +79,7 @@ def check_files(files):
         if not isinstance(content, str):
             findings.append(("files", f"{rel}: content must be a string"))
             continue
+        findings += _evidence_slice_denied(rel)
         size = len(content.encode("utf-8"))
         total += size
         if size > config.STAGE_MAX_FILE_BYTES:
@@ -132,6 +149,9 @@ def validate(intent, body, *, target_is_agent_created=None, repo_name=None, base
                 markers.append(repo_name)
             if markers:
                 findings.append(("global_repo_agnostic", markers))
+
+    if intent.get("action") == "remove_file":
+        findings += check_remove_path(intent.get("path"))
 
     if not (intent.get("reason") or "").strip() or not (intent.get("evidence") or "").strip():
         findings.append(("led", "intent missing reason/evidence"))

--- a/src/autoharness/stage_skill/server.py
+++ b/src/autoharness/stage_skill/server.py
@@ -6,9 +6,9 @@ landing all live in the deterministic promoter (admission model, untouchable by 
 front-checks "structure"; the promoter covers "shaping + content + security + landing" (defense in depth —
 the deterministic side does not fully trust the tool surface).
 
-- Schema enforcement: action enum; per-action body|delta required-and-mutually-exclusive; LED
-  reason/evidence required; create's level enum (default project; the layer for update/patch/delete is
-  resolved by the promoter via a two-layer find).
+- Schema enforcement: action enum; per-action body|delta|path required-and-mutually-exclusive; LED
+  reason/evidence required; create's level enum (default project; the layer for update/patch/
+  remove_file/delete is resolved by the promoter via a two-layer find).
 - Instant feedback on args: create/update run a structure check (frontmatter + name/description, reusing
   validate.structure) + body size, so the model can fix it on the spot within the subagent session
   instead of redoing a whole turn.
@@ -24,7 +24,7 @@ import sys
 from autoharness import config
 from autoharness.lib import intent_queue, layer, validate
 
-_ACTIONS = ("create", "update", "patch", "delete")
+_ACTIONS = ("create", "update", "patch", "remove_file", "delete")
 _BODY_ACTIONS = ("create", "update")
 TOOL_NAME = "stage_skill"
 _PROTOCOL_VERSION = "2024-11-05"
@@ -33,7 +33,8 @@ TOOL_SCHEMA = {
     "type": "object",
     "properties": {
         "action": {"type": "string", "enum": list(_ACTIONS),
-                   "description": "create=new (with level) / update=replace whole file / patch=small edit (delta) / delete=remove"},
+                   "description": "create=new (with level) / update=replace whole file / patch=small edit (delta) / "
+                                  "remove_file=drop one subfile / delete=remove the whole skill"},
         "name": {"type": "string", "description": "skill symbol name"},
         "level": {"type": "string", "enum": list(layer.LAYERS),
                   "description": "create only; defaults to project, global has a high bar"},
@@ -46,6 +47,9 @@ TOOL_SCHEMA = {
                   "description": "create/update only: subfiles as relative path -> content, under "
                                  "scripts/|templates/|assets/|references/; each must be referenced "
                                  "by its relative path in the SKILL.md body"},
+        "path": {"type": "string",
+                 "description": "remove_file only: relative path of the subfile to remove; the live "
+                                "SKILL.md must no longer reference it (patch the pointer out first)"},
     },
     "required": ["action", "name", "reason", "evidence"],
 }
@@ -69,6 +73,8 @@ def _schema_errors(params):
     has_body = params.get("body") is not None
     has_delta = params.get("old_string") is not None or params.get("new_string") is not None
     has_files = params.get("files") is not None
+    if action != "remove_file" and params.get("path") is not None:
+        errors.append(("schema", f"{action} takes no path (path is remove_file only)"))
     if action in _BODY_ACTIONS:
         if not has_body:
             errors.append(("schema", f"{action} requires body"))
@@ -87,6 +93,11 @@ def _schema_errors(params):
             errors.append(("schema", "patch requires both old_string and new_string"))
         if has_files:
             errors.append(("schema", "patch takes no files (use update to change subfiles)"))
+    elif action == "remove_file":
+        if not _nonempty(params, "path"):
+            errors.append(("schema", "remove_file requires path"))
+        if has_body or has_delta or has_files:
+            errors.append(("schema", "remove_file takes only path, no body/delta/files"))
     elif action == "delete":
         if has_body or has_delta:
             errors.append(("schema", "delete takes no body/delta"))
@@ -96,6 +107,8 @@ def _schema_errors(params):
 
 
 def _content_errors(params):
+    if params["action"] == "remove_file":
+        return validate.check_remove_path(params["path"])
     body = params.get("body")
     if body is None:
         return []
@@ -121,6 +134,8 @@ def _intent(params):
     elif action == "patch":
         intent["old_string"] = params["old_string"]
         intent["new_string"] = params["new_string"]
+    elif action == "remove_file":
+        intent["path"] = params["path"]
     return intent
 
 

--- a/tests/test_promoter.py
+++ b/tests/test_promoter.py
@@ -267,3 +267,90 @@ def test_delete_materializes_evidence_and_archives_it(tmp_path):
     assert len(slices) == 1 and slices[0].read_text() == "retire slice"  # provenance rides the mv
     entries = [json.loads(x) for x in (arch / ".ledger.jsonl").read_text().splitlines() if x.strip()]
     assert entries[-1]["evidence"].startswith("references/evidence-")
+
+
+# --- remove_file: single-subfile deletion channel ---
+
+NO_REF_BODY = "---\nname: foo\ndescription: Formats dates as ISO.\n---\n# Foo\nUse strftime.\n"
+
+
+def _remove(path="scripts/run.sh"):
+    return {"action": "remove_file", "name": "foo", "path": path,
+            "reason": "drop stale helper", "evidence": "remove slice"}
+
+
+def _live_with_subfile(roots):
+    v = promoter.promote({**_create(body=FILES_BODY),
+                          "files": {"scripts/run.sh": "echo hi\n"}}, roots=roots)
+    assert v["ok"], v["findings"]
+
+
+def test_remove_file_unlinks_ledgers_keeps_body(tmp_path):
+    roots = _roots(tmp_path)
+    _live_with_subfile(roots)
+    patch = {"action": "patch", "name": "foo", "old_string": "Run scripts/run.sh",
+             "new_string": "Use strftime.", "reason": "r", "evidence": "e"}
+    assert promoter.promote(patch, roots=roots)["ok"]  # drop the pointer first
+    v = promoter.promote(_remove(), roots=roots)
+    assert v["ok"], v["findings"]
+    assert not (_sdir(roots) / "scripts" / "run.sh").exists()
+    assert skill_store.exists("project", "foo", roots["project"])  # skill itself stays live
+    entry = ledger.read("project", "foo", roots["project"])[-1]
+    assert entry["action"] == "remove_file" and entry["path"] == "scripts/run.sh"
+    assert entry["evidence"].startswith("references/evidence-")
+
+
+def test_remove_file_still_referenced_rejected(tmp_path):
+    roots = _roots(tmp_path)
+    _live_with_subfile(roots)  # FILES_BODY still points at scripts/run.sh
+    v = promoter.promote(_remove(), roots=roots)
+    assert not v["ok"] and "landing" in _families(v)
+    assert (_sdir(roots) / "scripts" / "run.sh").exists()  # nothing removed
+
+
+def test_remove_file_user_skill_rejected(tmp_path):
+    roots = _roots(tmp_path)
+    root = roots["project"]
+    skill_store.write_body("project", "foo", NO_REF_BODY, root)  # no sidecar: user-owned
+    (layer.symbol_dir("project", "foo", root) / "scripts").mkdir()
+    (layer.symbol_dir("project", "foo", root) / "scripts" / "run.sh").write_text("x")
+    v = promoter.promote(_remove(), roots=roots)
+    assert not v["ok"] and "self_produced" in _families(v)
+    assert (_sdir(roots) / "scripts" / "run.sh").exists()
+
+
+def test_remove_file_missing_target_file_is_noop_ok(tmp_path):
+    roots = _roots(tmp_path)
+    promoter.promote(_create(body=NO_REF_BODY), roots=roots)
+    v = promoter.promote(_remove(path="scripts/never-existed.sh"), roots=roots)
+    assert v["ok"], v["findings"]  # idempotent: crash-replay safe
+    assert ledger.read("project", "foo", roots["project"])[-1]["action"] == "remove_file"
+
+
+def test_remove_file_missing_skill_rejected(tmp_path):
+    v = promoter.promote(_remove(), roots=_roots(tmp_path))
+    assert not v["ok"] and "routing" in _families(v)
+
+
+def test_remove_file_evidence_slice_rejected_zero_disk(tmp_path):
+    roots = _roots(tmp_path)
+    promoter.promote(_create(body=NO_REF_BODY), roots=roots)
+    slice_rel = ledger.read("project", "foo", roots["project"])[0]["evidence"]
+    v = promoter.promote(_remove(path=slice_rel), roots=roots)
+    assert not v["ok"] and "files" in _families(v)
+    assert (_sdir(roots) / slice_rel).exists()  # provenance untouched
+
+
+def test_remove_file_symlink_escape_rejected(tmp_path):
+    roots = _roots(tmp_path)
+    root = roots["project"]
+    skill_store.write_body("project", "foo", NO_REF_BODY, root)
+    sidecar.create("project", "foo", 0, root)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    victim = outside / "victim.sh"
+    victim.write_text("keep me")
+    (_sdir(roots) / "scripts").symlink_to(outside)
+    v = promoter.promote(_remove(path="scripts/victim.sh"), roots=roots)
+    assert not v["ok"] and "landing" in _families(v)
+    assert victim.read_text() == "keep me"  # nothing outside the skill dir was touched

--- a/tests/test_stage_skill.py
+++ b/tests/test_stage_skill.py
@@ -281,3 +281,68 @@ def test_serve_loops_stdin_to_stdout(tmp_path):
     server.serve(stdin=stdin, stdout=stdout)
     line = stdout.getvalue().strip()
     assert json.loads(line)["result"]["serverInfo"]["name"] == server.TOOL_NAME
+
+
+# --- remove_file (single-subfile deletion) ---
+
+def _remove(**kw):
+    base = {"action": "remove_file", "name": "foo", "path": "scripts/run.sh",
+            "reason": "r", "evidence": "e"}
+    base.update(kw)
+    return base
+
+
+def test_tool_schema_advertises_remove_file():
+    assert "remove_file" in server.TOOL_SCHEMA["properties"]["action"]["enum"]
+    assert server.TOOL_SCHEMA["properties"]["path"]["type"] == "string"
+
+
+def test_remove_file_appends_intent(tmp_path):
+    v = server.stage(_remove(), run_id=RUN, root=tmp_path)
+    assert v["ok"], v["errors"]
+    assert _queue(tmp_path) == [{"action": "remove_file", "name": "foo",
+                                 "path": "scripts/run.sh", "reason": "r", "evidence": "e"}]
+    assert not layer.skills_dir("project", tmp_path).exists()  # still zero tree write
+
+
+def test_remove_file_requires_path(tmp_path):
+    p = _remove()
+    del p["path"]
+    v = server.stage(p, run_id=RUN, root=tmp_path)
+    assert not v["ok"] and "schema" in _errs(v)
+    assert _queue(tmp_path) == []
+
+
+def test_remove_file_rejects_body_delta_files(tmp_path):
+    for kw in ({"body": GOOD_BODY}, {"old_string": "a", "new_string": "b"}, {"files": GOOD_FILES}):
+        v = server.stage(_remove(**kw), run_id=RUN, root=tmp_path)
+        assert not v["ok"] and "schema" in _errs(v), kw
+    assert _queue(tmp_path) == []
+
+
+def test_path_on_other_actions_rejected(tmp_path):
+    v = server.stage(_params(path="scripts/run.sh"), run_id=RUN, root=tmp_path)
+    assert not v["ok"] and "schema" in _errs(v)
+    assert _queue(tmp_path) == []
+
+
+def test_remove_file_path_gate_red_team(tmp_path):
+    for bad in ("../x", "/etc/passwd", "scripts/../SKILL.md", "SKILL.md",
+                ".sidecar.json", "bin/x.sh"):
+        v = server.stage(_remove(path=bad), run_id=RUN, root=tmp_path)
+        assert not v["ok"] and "files" in _errs(v), bad
+    assert _queue(tmp_path) == []
+
+
+def test_remove_file_evidence_slice_denied(tmp_path):
+    v = server.stage(_remove(path="references/evidence-a1b2c3d4.md"), run_id=RUN, root=tmp_path)
+    assert not v["ok"] and "files" in _errs(v)
+    assert _queue(tmp_path) == []
+
+
+def test_files_carrying_evidence_slice_denied(tmp_path):
+    body = FILES_BODY + "See references/evidence-ffff.md\n"  # pointed at, still denied
+    files = {**GOOD_FILES, "references/evidence-ffff.md": "forged"}
+    v = server.stage(_params(body=body, files=files), run_id=RUN, root=tmp_path)
+    assert not v["ok"] and "files" in _errs(v)
+    assert _queue(tmp_path) == []

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -126,3 +126,42 @@ def test_global_subfile_repo_local_rejected():
               "files": {"references/notes.md": "Run /home/ryan/tigerless_ai/x.py\n"}}
     body = GOOD_BODY + "\nSee references/notes.md\n"
     assert "global_repo_agnostic" in _families(validate.validate(intent, body))
+
+
+# --- remove_file + evidence-slice write/remove deny ---
+
+REMOVE_INTENT = {"action": "remove_file", "name": "foo", "path": "scripts/run.sh",
+                 "reason": "r", "evidence": "e"}
+
+
+def test_check_files_evidence_slice_denied():
+    fs = {"references/evidence-a1b2c3d4.md": "forged provenance"}
+    assert any(f[0] == "files" for f in validate.check_files(fs))
+
+
+def test_remove_file_clean_passes():
+    v = validate.validate(REMOVE_INTENT, None, target_is_agent_created=True)
+    assert v["ok"], v["findings"]
+
+
+def test_remove_file_bad_path_rejected():
+    for bad in ("../x", "/etc/passwd", "SKILL.md", "bin/x.sh", "", None):
+        v = validate.validate({**REMOVE_INTENT, "path": bad}, None, target_is_agent_created=True)
+        assert not v["ok"] and "files" in _families(v), bad
+
+
+def test_remove_file_evidence_slice_denied():
+    v = validate.validate({**REMOVE_INTENT, "path": "references/evidence-a1b2c3d4.md"},
+                          None, target_is_agent_created=True)
+    assert not v["ok"] and "files" in _families(v)
+
+
+def test_remove_file_requires_agent_tag():
+    v = validate.validate(REMOVE_INTENT, None, target_is_agent_created=False)
+    assert not v["ok"] and "self_produced" in _families(v)
+
+
+def test_remove_file_missing_led_rejected():
+    v = validate.validate({**REMOVE_INTENT, "reason": "", "evidence": ""},
+                          None, target_is_agent_created=True)
+    assert not v["ok"] and "led" in _families(v)


### PR DESCRIPTION
## Why

`update`'s `files` could only add or overwrite subfiles: a subfile no longer referenced by the body could not be dropped short of deleting the whole skill. Hermes ships this exact surface as `skill_manage`'s `remove_file` — this PR adds the equivalent while keeping the propose/promote split (the model stages an intent; the deterministic promoter validates and unlinks).

It also implements a rule `validate`'s docstring already claimed but never enforced: promoter-materialized `references/evidence-*` slices are off-limits to intents — in **both** directions (carried in `files`, or targeted by `remove_file`).

## What

- **stage_skill**: `remove_file` action + `path` arg; `body`/`delta`/`files`/`path` mutually exclusive per action; staging-side instant feedback runs the path gate + evidence deny.
- **validate**: `check_remove_path` (subfile whitelist + evidence deny); `check_files` now denies evidence-prefix keys; `remove_file` joins the self-produced modify set (target must be `created_by:agent`).
- **promoter**: `remove_file` branch — path re-gated with resolve + symlink-escape check before any change; **rejected while the live SKILL.md still references the path** (no dangling pointers; patch the pointer out first, both intents land in queue order); missing target = no-op so crash replays stay idempotent; evidence materialized; LED entry carries the removed `path`.
- **layer.EVIDENCE_PREFIX**: single source for the materialization naming and both denials.
- **reflector prompt + format spec**: document the patch-pointer-then-remove flow and the evidence-slice prohibition.

## Tests

19 new tests across `test_stage_skill` / `test_validate` / `test_promoter`, incl. red-team cases: path-traversal reds, symlink escape (victim outside the tree untouched), forged-evidence carry, evidence-slice removal, user-skill target. Suite: 278 passed. Verified end-to-end over the real stdio JSON-RPC server → intent queue → `promoter.drain`: subfile landed, pointer patched out, file unlinked, LED carries `path`, forged evidence removal rejected at the tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)