### PR TITLE
chore: bump version to 0.2.10

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autoharness",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "Per-symbol maintenance optimizer for an agent's skill layer — learns skills from real runs and keeps them by adherence in use, not by an offline eval score.",
   "author": { "name": "Tigerless Labs" },
   "homepage": "https://github.com/tigerless-labs/autoharness",

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <h1 align="center">autoharness</h1>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/release-v0.2.9-brightgreen.svg" alt="release" />
+  <img src="https://img.shields.io/badge/release-v0.2.10-brightgreen.svg" alt="release" />
   <img src="https://img.shields.io/badge/python-3.11%2B-blue.svg" alt="python" />
   <img src="https://img.shields.io/badge/platform-Linux%20%7C%20macOS-lightgrey.svg" alt="platform" />
   <img src="https://img.shields.io/badge/license-MIT-yellow.svg" alt="license MIT" />


### PR DESCRIPTION
Version bump for PR #64 (remove_file single-subfile deletion channel + evidence-slice intent gate): plugin.json + README release badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)