### PR TITLE
prompt: reflector — umbrella-first creation + consolidate existing overlap

### DIFF
--- a/agents/reflector.md
+++ b/agents/reflector.md
@@ -35,7 +35,7 @@ Scan the description index across **both** layers first, look closely (with your
 1. **`patch` A CURRENTLY-LOADED SKILL.** Look back through the episode trace for skills that were loaded or consulted. If any of them covers the territory of the new learning, `patch` that one first — it is the skill that was in play, so it's the right one to extend.
 2. **`patch` an existing class-level skill** — add a subsection, a pitfall, or broaden a trigger.
 3. **`update` an existing skill with support subfiles** (carrying `files`), when the lesson is detail backing an existing skill rather than new behavior.
-4. **`create` a new skill.** Prefer a class-level name that covers a class of work rather than a session artifact. If nothing existing fits — or you are unsure whether it fits — create; the lifecycle layer prunes redundancy later.
+4. **`create` a new skill — born as an umbrella.** Even a brand-new skill starts from the *class* of work, never this one session: ask "what category is this an instance of?" and create *that* category, with today's lesson as its first case. Name and scope it class-level so the next same-scenario lesson `patch`es into it instead of spawning a sibling — a skill deliberately born broad is what makes later consolidation cheap, while a session-shaped skill (`fix-X-in-file-Y`) forces a refactor no downstream layer can do for you. If nothing existing fits — or you are unsure whether it fits — create; the lifecycle layer prunes redundancy later.
 
 ## Subfiles (the `files` argument, create/update only)
 

--- a/agents/reflector.md
+++ b/agents/reflector.md
@@ -37,6 +37,8 @@ Scan the description index across **both** layers first, look closely (with your
 3. **`update` an existing skill with support subfiles** (carrying `files`), when the lesson is detail backing an existing skill rather than new behavior.
 4. **`create` a new skill — born as an umbrella.** Even a brand-new skill starts from the *class* of work, never this one session: ask "what category is this an instance of?" and create *that* category, with today's lesson as its first case. Name and scope it class-level so the next same-scenario lesson `patch`es into it instead of spawning a sibling — a skill deliberately born broad is what makes later consolidation cheap, while a session-shaped skill (`fix-X-in-file-Y`) forces a refactor no downstream layer can do for you. If nothing existing fits — or you are unsure whether it fits — create; the lifecycle layer prunes redundancy later.
 
+**Consolidate existing overlap (not only this episode's lesson).** While scanning the index you may see two *existing* skills that already cover the same class — near-duplicates that predate this episode. When the overlap is unmistakable (not merely adjacent), fold them: `patch` the broader one to absorb whatever the narrower adds, then `delete` the redundant narrower one. This is the only case where you act on skills the current episode never touched. Cite the two overlapping index entries as the `evidence` — that observation is what triggered the merge.
+
 ## Subfiles (the `files` argument, create/update only)
 
 A skill is a folder. Besides the SKILL.md body, `create`/`update` may carry `files`: a map of relative path → content, under exactly these directories:

--- a/tests/test_reflector_agent.py
+++ b/tests/test_reflector_agent.py
@@ -50,3 +50,12 @@ def test_reflector_create_is_umbrella_first():
     body = AGENT.read_text().lower()
     assert "umbrella" in body  # new skills are born as a category, not a session artifact
     assert body.index("umbrella") > body.index("`create`")  # the emphasis lands on the create rung
+
+
+def test_reflector_can_consolidate_existing_overlap():
+    body = AGENT.read_text().lower()
+    # (a) global consolidation on the cheap: the reflector may fold two PRE-EXISTING overlapping
+    # skills together — not only capture the current episode's lesson. Distinctive to this rule
+    # is that it deletes a *redundant existing* skill the episode never touched.
+    assert "redundant" in body
+    assert "delete" in body

--- a/tests/test_reflector_agent.py
+++ b/tests/test_reflector_agent.py
@@ -44,3 +44,9 @@ def test_reflector_prompt_encourages_generation():
     body = AGENT.read_text().lower()
     assert "one intent per" in body
     assert body.index("patch") < body.index("`create`")
+
+
+def test_reflector_create_is_umbrella_first():
+    body = AGENT.read_text().lower()
+    assert "umbrella" in body  # new skills are born as a category, not a session artifact
+    assert body.index("umbrella") > body.index("`create`")  # the emphasis lands on the create rung


### PR DESCRIPTION
Two related reflector-prompt changes on the merge/umbrella theme, ported from Hermes's every-episode `_SKILL_REVIEW_PROMPT`.

1. **create rung born as an umbrella** — a new skill starts from the class of work, not this session, so the next same-scenario lesson patches in instead of spawning a sibling.
2. **consolidate existing overlap** — the cheap half of Hermes's global curator: when the index shows two pre-existing skills covering the same class, the reflector folds them (patch the broader to absorb, delete the redundant narrower). This is the only case where it acts on skills the current episode never touched.

Known ceilings (absorbed calls not transferred to the survivor's MNG rate; consolidation evidence is the index, not an episode-trace slice) are tracked in docs/TODO.md; revisit if duplication data says they matter.