### PR TITLE
chore: bump version to 0.2.11

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autoharness",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "description": "Per-symbol maintenance optimizer for an agent's skill layer — learns skills from real runs and keeps them by adherence in use, not by an offline eval score.",
   "author": { "name": "Tigerless Labs" },
   "homepage": "https://github.com/tigerless-labs/autoharness",


### PR DESCRIPTION
Version bump for the reflector merge/umbrella changes merged since 0.2.10:

- **PR #70** — umbrella-first creation + consolidate existing overlap (the functional change)
- #67–#69, #71 — README/wording refinements

Nothing else since 0.2.10 touched behavior.