### PR TITLE
mng: numerator counts Read into managed skill dirs

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -7,7 +7,7 @@
       { "hooks": [ { "type": "command", "command": "PYTHONPATH=${CLAUDE_PLUGIN_ROOT}/src python3 -m autoharness.hook.dispatch" } ] }
     ],
     "PreToolUse": [
-      { "matcher": "Skill", "hooks": [ { "type": "command", "command": "PYTHONPATH=${CLAUDE_PLUGIN_ROOT}/src python3 -m autoharness.hook.dispatch" } ] },
+      { "matcher": "Skill|Read", "hooks": [ { "type": "command", "command": "PYTHONPATH=${CLAUDE_PLUGIN_ROOT}/src python3 -m autoharness.hook.dispatch" } ] },
       { "matcher": "Write|Edit|MultiEdit|NotebookEdit", "hooks": [ { "type": "command", "command": "PYTHONPATH=${CLAUDE_PLUGIN_ROOT}/src python3 -m autoharness.hook.dispatch" } ] }
     ],
     "SessionEnd": [

--- a/src/autoharness/hook/dispatch.py
+++ b/src/autoharness/hook/dispatch.py
@@ -6,9 +6,10 @@ missing event names are safely ignored (fail-safe — a new host event must not 
 platform contract pins the details:
 - `Stop` = once per turn (S6) → on Stop, +1 each to both layers' request counters (the MNG-rate
   denominator), then run CAP triggering; `SubagentStop` (reflector done, S4) is not routed, not counted.
-- `PreToolUse`: `Skill` → MNG numerator instrumentation (identity in `tool_input`, S5); reflector
-  `agent_type` (carried in the S3 payload) on `Write`/`Edit` → deny (plugin top-level backstop — a
-  plugin agent does not honor its own hooks, S1).
+- `PreToolUse`: `Skill` → MNG numerator instrumentation (identity in `tool_input`, S5); `Read` into a
+  managed symbol directory → same numerator (the dominant consumption path, E8), except reflector
+  reads (library comparison, not use); reflector `agent_type` (carried in the S3 payload) on
+  `Write`/`Edit` → deny (plugin top-level backstop — a plugin agent does not honor its own hooks, S1).
 - Triggering reflection starts in a detached background job (host-detach: do not block the host Stop);
   the spawn CLI entry connects to the promoter.
 
@@ -85,6 +86,10 @@ def dispatch(event, *, roots=None, reflect=None):
             tool = event.get("tool_name")
             if tool == "Skill":
                 return {"handled": name, "result": on_skill_call.on_skill_call(event, roots=roots)}
+            if tool == "Read":
+                if _is_reflector(event):
+                    return {"handled": name, "result": {"counted": False, "reason": "reflector_read"}}
+                return {"handled": name, "result": on_skill_call.on_skill_read(event, roots=roots)}
             if tool in _WRITE_TOOLS and _is_reflector(event):
                 return {"deny": True, "reason": "reflector may only stage intents, not write files"}
             return {"ignored": True, "reason": "untracked PreToolUse"}

--- a/src/autoharness/hook/on_skill_call.py
+++ b/src/autoharness/hook/on_skill_call.py
@@ -1,17 +1,20 @@
-"""MNG numerator instrumentation: at `PreToolUse(Skill)`, +1 the called symbol's sidecar calls, pure observation, no interception.
+"""MNG numerator instrumentation: at `PreToolUse(Skill)` and `PreToolUse(Read)` into a managed symbol directory, +1 the used symbol's sidecar calls, pure observation, no interception.
 
-mng.md: the rate numerator = number of calls, stored in the called symbol's sidecar, layer-agnostic
-(identity decides which layer). **Zero-intrusion red line — count only self-produced symbols**, never
-write a sidecar for native / user skills (touching them violates "do not touch the host's work").
-Recursion guard same as CAP: a reflector child session is not counted. Bad / unknown / same-name
-ambiguous symbols fail-safe without crashing the host hook.
+mng.md: the rate numerator = number of uses, stored in the used symbol's sidecar, layer-agnostic
+(identity decides which layer). Measured (experiments/E8_numerator_capture): the model's dominant
+consumption path is a direct Read of SKILL.md / subfiles, almost never the Skill tool, so the Read
+path is the load-bearing half of the numerator. **Zero-intrusion red line — count only self-produced
+symbols**, never write a sidecar for native / user skills (touching them violates "do not touch the
+host's work"). Recursion guard same as CAP: a reflector child session is not counted. Bad / unknown /
+same-name ambiguous symbols and reads under `.archive` fail-safe without crashing the host hook.
 
 ponytail: the exact key for a symbol's identity in the event = Phase 0 spike (mng.md open); for now extract with field-tolerant fallbacks over a few candidate keys.
 """
 import os
+from pathlib import Path
 
 from autoharness import config
-from autoharness.lib import sidecar, skill_store
+from autoharness.lib import layer, sidecar, skill_store
 
 
 def _skill_name(event):
@@ -24,11 +27,24 @@ def _skill_name(event):
     return None
 
 
-def on_skill_call(event, *, roots=None):
-    if os.environ.get(config.CHILD_SESSION_ENV):
-        return {"counted": False, "reason": "recursion_guard"}
-    roots = roots or {}
-    name = _skill_name(event)
+def _name_from_read_path(event, roots):
+    nested = event.get("tool_input") if isinstance(event.get("tool_input"), dict) else {}
+    file_path = nested.get("file_path") or event.get("file_path")
+    if not isinstance(file_path, str) or not file_path.strip():
+        return None
+    target = Path(file_path)
+    for lyr in layer.LAYERS:
+        base = layer.skills_dir(lyr, roots.get(lyr))
+        try:
+            rel = target.resolve().relative_to(base.resolve())
+        except (ValueError, OSError):
+            continue
+        if len(rel.parts) > 1 and rel.parts[0] != ".archive":
+            return rel.parts[0]
+    return None
+
+
+def _count(name, roots):
     if not name:
         return {"counted": False, "reason": "no_skill"}
     try:
@@ -42,3 +58,16 @@ def on_skill_call(event, *, roots=None):
         return {"counted": False, "reason": "not_agent_created"}
     calls = sidecar.bump_calls(lyr, name, root)
     return {"counted": True, "level": lyr, "name": name, "calls": calls}
+
+
+def on_skill_call(event, *, roots=None):
+    if os.environ.get(config.CHILD_SESSION_ENV):
+        return {"counted": False, "reason": "recursion_guard"}
+    return _count(_skill_name(event), roots or {})
+
+
+def on_skill_read(event, *, roots=None):
+    if os.environ.get(config.CHILD_SESSION_ENV):
+        return {"counted": False, "reason": "recursion_guard"}
+    roots = roots or {}
+    return _count(_name_from_read_path(event, roots), roots)

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -111,6 +111,31 @@ def test_pretooluse_skill_counts_numerator(tmp_path):
     assert sidecar.read("project", "foo", root)["calls"] == 1
 
 
+def test_pretooluse_read_of_skill_counts_numerator(tmp_path):
+    roots = _roots(tmp_path)
+    root = roots[layer.PROJECT]
+    skill_store.write_body("project", "foo", "b", root)
+    sidecar.create("project", "foo", anchor=0, root=root)
+    out = dispatch.dispatch({"hook_event_name": "PreToolUse", "tool_name": "Read",
+                             "tool_input": {"file_path": str(root / "skills" / "foo" / "SKILL.md")}},
+                            roots=roots)
+    assert out["result"]["counted"]
+    assert sidecar.read("project", "foo", root)["calls"] == 1
+
+
+def test_reflector_read_not_counted(tmp_path):
+    roots = _roots(tmp_path)
+    root = roots[layer.PROJECT]
+    skill_store.write_body("project", "foo", "b", root)
+    sidecar.create("project", "foo", anchor=0, root=root)
+    out = dispatch.dispatch({"hook_event_name": "PreToolUse", "tool_name": "Read",
+                             "agent_type": "autoharness:reflector",
+                             "tool_input": {"file_path": str(root / "skills" / "foo" / "SKILL.md")}},
+                            roots=roots)
+    assert not out["result"]["counted"]
+    assert sidecar.read("project", "foo", root)["calls"] == 0
+
+
 def test_reflector_write_is_denied(tmp_path):
     out = dispatch.dispatch({"hook_event_name": "PreToolUse", "tool_name": "Write",
                              "agent_type": "autoharness:reflector"}, roots=_roots(tmp_path))

--- a/tests/test_on_skill_call.py
+++ b/tests/test_on_skill_call.py
@@ -55,6 +55,65 @@ def test_missing_name_failsafe(tmp_path):
     assert not on_skill_call.on_skill_call({}, roots=_roots(tmp_path))["counted"]
 
 
+def _read_event(path):
+    return {"tool_name": "Read", "tool_input": {"file_path": str(path)}}
+
+
+def test_read_of_skill_file_bumps_numerator(tmp_path):
+    roots = _roots(tmp_path)
+    root = _seed_agent_skill(roots)
+    r = on_skill_call.on_skill_read(_read_event(root / "skills" / "foo" / "SKILL.md"), roots=roots)
+    assert r["counted"] and r["level"] == "project"
+    assert sidecar.read("project", "foo", root)["calls"] == 1
+
+
+def test_read_of_skill_subfile_bumps_numerator(tmp_path):
+    roots = _roots(tmp_path)
+    root = _seed_agent_skill(roots)
+    r = on_skill_call.on_skill_read(
+        _read_event(root / "skills" / "foo" / "references" / "evidence-1.md"), roots=roots)
+    assert r["counted"]
+    assert sidecar.read("project", "foo", root)["calls"] == 1
+
+
+def test_read_outside_skills_not_counted(tmp_path):
+    roots = _roots(tmp_path)
+    _seed_agent_skill(roots)
+    r = on_skill_call.on_skill_read(_read_event(tmp_path / "elsewhere" / "SKILL.md"), roots=roots)
+    assert not r["counted"]
+
+
+def test_read_of_archived_skill_not_counted(tmp_path):
+    roots = _roots(tmp_path)
+    root = _seed_agent_skill(roots)
+    r = on_skill_call.on_skill_read(
+        _read_event(root / "skills" / ".archive" / "foo" / "SKILL.md"), roots=roots)
+    assert not r["counted"]
+    assert sidecar.read("project", "foo", root)["calls"] == 0
+
+
+def test_read_of_non_agent_skill_never_touched(tmp_path):
+    roots = _roots(tmp_path)
+    root = roots["project"]
+    skill_store.write_body("project", "native", "b", root)
+    r = on_skill_call.on_skill_read(_read_event(root / "skills" / "native" / "SKILL.md"), roots=roots)
+    assert not r["counted"] and r["reason"] == "not_agent_created"
+    assert sidecar.read("project", "native", root) == {}
+
+
+def test_read_missing_path_failsafe(tmp_path):
+    assert not on_skill_call.on_skill_read({"tool_name": "Read"}, roots=_roots(tmp_path))["counted"]
+
+
+def test_read_recursion_guard_does_not_count(tmp_path, monkeypatch):
+    monkeypatch.setenv(config.CHILD_SESSION_ENV, "1")
+    roots = _roots(tmp_path)
+    root = _seed_agent_skill(roots)
+    r = on_skill_call.on_skill_read(_read_event(root / "skills" / "foo" / "SKILL.md"), roots=roots)
+    assert not r["counted"] and r["reason"] == "recursion_guard"
+    assert sidecar.read("project", "foo", root)["calls"] == 0
+
+
 def test_recursion_guard_does_not_count(tmp_path, monkeypatch):
     monkeypatch.setenv(config.CHILD_SESSION_ENV, "1")
     roots = _roots(tmp_path)

--- a/tests/test_plugin_manifest.py
+++ b/tests/test_plugin_manifest.py
@@ -24,9 +24,11 @@ def test_hooks_route_all_events_to_dispatch():
     assert (ROOT / "src/autoharness/hook/dispatch.py").exists()
 
 
-def test_pretooluse_scoped_to_skill():
+def test_pretooluse_covers_skill_and_read_numerator():
     pre = _load("hooks/hooks.json")["hooks"]["PreToolUse"]
-    assert any(group.get("matcher") == "Skill" for group in pre)
+    matchers = [group.get("matcher") or "" for group in pre]
+    assert any("Skill" in m for m in matchers)
+    assert any("Read" in m for m in matchers)
 
 
 def test_pretooluse_backstops_reflector_writes():


### PR DESCRIPTION
## Problem

MNG's rate numerator only counted `PreToolUse(Skill)`. Transcript measurement over 189 lara sessions (recorded in `experiments/E8_numerator_capture`, local): learned skills are consumed via direct `Read` of SKILL.md/subfiles (60+ hits across 20+ self-produced skills), almost never via the Skill tool (1 hit — exactly matching the single `calls=1` sidecar in the whole library). Result: 33/34 mature skills showed calls=0, so rate-based ranking could never work.

## Change

- `on_skill_call`: extract a shared counting core; new `on_skill_read` resolves the symbol name from the Read `file_path` under either layer's skills dir. Reads under `.archive` and non-skill paths are no-ops; same guards as before (agent-created only, recursion guard, fail-safe).
- `dispatch`: route `PreToolUse(Read)`; reflector reads are not counted (library comparison is not use).
- `hooks.json`: PreToolUse matcher `Skill` → `Skill|Read`.

## Verification

- 289 unit/system tests pass, ruff clean.
- E2E against the real dispatch module via stdin: Read into a managed skill dir bumps sidecar calls 0→1; non-skill Read leaves state untouched and emits no deny.

Design doc (`docs/research-loom-en/design/mng.md`, untracked English tree) updated alongside: numerator definition + open item ① resolved; graduation review (zero calls at maturity → archive, never enters the pool) recorded as settled, to be implemented as the next change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)