### PR TITLE
mng: graduation review — zero use across a full probation never enters the pool

### DIFF
--- a/src/autoharness/lib/lifecycle.py
+++ b/src/autoharness/lib/lifecycle.py
@@ -1,15 +1,16 @@
-"""MNG decision: purely deterministic, call-rate + probation + capacity contention → produces the "to-archive list". Touches no disk.
+"""MNG decision: purely deterministic, call-rate + probation + graduation review + capacity contention → produces the "to-archive list". Touches no disk.
 
 mng.md: the survival criterion is **call rate** (call count / layer requests since creation), not
 wall-clock. Probation protects the new (denominator below the maturity threshold = live but not
-evicted, not counted against the cap). Capacity contention is the ONLY death: when the mature pool
-exceeds the cap, archive the lowest by ascending rate — zero-call symbols simply sit at the bottom.
-The decision only reads cumulative watermarks (sidecar calls + anchor, layer request count), so any
-repo's SessionStart reaches the same conclusion. on_session_start takes this list and runs
+evicted, not counted against the cap). Graduation review sits exactly at the probation boundary:
+a mature symbol with zero calls is archived and never enters the pool — a full probation with no
+use is genuine dormancy now that the numerator counts the Read path. Graduates (calls ≥ 1) die
+only by capacity contention: when the mature pool exceeds the cap, archive the lowest by ascending
+rate. The decision only reads cumulative watermarks (sidecar calls + anchor, layer request count),
+so any repo's SessionStart reaches the same conclusion. on_session_start takes this list and runs
 skill_store.archive on each.
 
-ponytail: an absolute floor rule (independent hard floor Y) and a rolling-window rate are
-deferred (open in mng.md).
+ponytail: a rolling-window rate is deferred (open in mng.md).
 """
 
 
@@ -24,7 +25,11 @@ def evaluate(members, request_count, *, maturity, capacity):
         denom = max(0, request_count - m.get("anchor", 0))
         if denom < maturity:
             continue  # probation: live, not evicted, not counted against the cap
-        survivors.append((_rate(m.get("calls", 0), denom), m["name"]))
+        calls = m.get("calls", 0)
+        if calls == 0:
+            archive.add(m["name"])  # graduation review: a full probation with zero use never enters the pool
+            continue
+        survivors.append((_rate(calls, denom), m["name"]))
     if len(survivors) > capacity:
         survivors.sort(key=lambda rn: rn)  # ascending rate, ties broken stably by name
         archive.update(name for _, name in survivors[: len(survivors) - capacity])

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -11,16 +11,23 @@ def test_probation_never_archived():
     assert out == []
 
 
-def test_mature_zero_calls_survives_without_capacity_pressure():
-    # denom = 20 ≥ maturity 10, calls 0, pool under cap → capacity contention is the only death
+def test_graduation_review_archives_mature_zero_calls_without_capacity_pressure():
+    # denom = 20 ≥ maturity 10, calls 0 → archived at review, never enters the pool
     out = lifecycle.evaluate([_m("idle", 0)], request_count=20, maturity=10, capacity=5)
+    assert out == ["idle"]
+
+
+def test_graduated_low_rate_survives_without_capacity_pressure():
+    # calls ≥ 1 graduates; low rate alone is not a death line (capacity contention is)
+    out = lifecycle.evaluate([_m("rare", 1)], request_count=1000, maturity=10, capacity=5)
     assert out == []
 
 
-def test_mature_zero_calls_evicted_first_under_capacity_pressure():
-    members = [_m("idle", 0), _m("used", 30)]
+def test_review_and_capacity_compose():
+    # idle archived by review; the graduated pool then contends for capacity separately
+    members = [_m("idle", 0), _m("hi", 80), _m("lo", 5)]
     out = lifecycle.evaluate(members, request_count=100, maturity=10, capacity=1)
-    assert out == ["idle"]
+    assert out == ["idle", "lo"]
 
 
 def test_capacity_competition_archives_lowest_rate():

--- a/tests/test_on_session_start.py
+++ b/tests/test_on_session_start.py
@@ -81,10 +81,10 @@ def test_second_run_is_noop_after_archival(tmp_path, monkeypatch):
     assert on_session_start.on_session_start(roots=roots)["archived"]["project"] == []
 
 
-def test_mature_zero_calls_survives_without_capacity_pressure(tmp_path, monkeypatch):
+def test_graduation_review_archives_mature_zero_calls(tmp_path, monkeypatch):
     _small_knobs(monkeypatch, cap_project=5)
     roots = _roots(tmp_path)
     _set_requests(roots, "project", 100)
-    _seed(roots, "idle", calls=0)  # mature, rate 0 — but pool under cap → survives
-    assert on_session_start.on_session_start(roots=roots)["archived"]["project"] == []
-    assert skill_store.exists("project", "idle", roots["project"])
+    _seed(roots, "idle", calls=0)  # full probation, zero use → archived even under cap
+    assert on_session_start.on_session_start(roots=roots)["archived"]["project"] == ["idle"]
+    assert not skill_store.exists("project", "idle", roots["project"])


### PR DESCRIPTION
## Design (settled with the user, recorded in mng.md "Graduation review")

One knob (the maturity threshold) now carries the whole probation boundary:

- denominator < threshold → probation, untouchable (unchanged)
- at maturity, **calls == 0 → archived, never enters the mature pool** (reversible move-out, not delete)
- calls ≥ 1 → graduates; capacity contention stays the only death thereafter (unchanged)

This replaces the previously-planned standalone floor knob and dissolves the probation-vs-zero-call-exit conflict — the review sits exactly at the boundary between them. It resurrects the graduation review deleted on 2026-07-06: that deletion's real cause was numerator distortion (Read-path usage uncounted, fixed in #73), so zero calls across a full probation is now a genuine dormancy signal.

Stateless: evaluate recomputes over cumulative watermarks each SessionStart, so any repo reaches the same conclusion.

## Verification

- 290 unit/system tests pass, ruff clean.
- E2E via the real dispatch module on a seeded layout (requests=200, maturity=100): zero-call symbol moved to `.archive`, calls=3 symbol survives.

## Deploy note (one-off, before updating consumer repos)

Historical calls were systematically undercounted before #73 (in lara: 33/34 mature symbols show calls=0 while 20+ were genuinely Read). Before this rule reaches a consumer repo, re-anchor live zero-call agent-created symbols (anchor = current layer request count) so everyone re-runs probation under the fixed numerator — genuinely dead ones expire after one threshold window, used ones accumulate calls and graduate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)