### PR TITLE
config: reflect cadence 3 -> 10 turns per window

### DIFF
--- a/src/autoharness/config.py
+++ b/src/autoharness/config.py
@@ -18,7 +18,7 @@ def _int_env(name, default):
         return default
 
 
-REFLECT_EVERY_N = _int_env("AUTOHARNESS_REFLECT_EVERY_N", 3)  # trigger cadence; the window itself is watermark-delimited (capture)
+REFLECT_EVERY_N = _int_env("AUTOHARNESS_REFLECT_EVERY_N", 10)  # trigger cadence; the window itself is watermark-delimited (capture)
 
 # raw-capture byte caps (ponytail: placeholders, calibrate in experiments/): per transcript record,
 # and per handoff window (tail kept) — bound tool dumps / base64 away from the child context.


### PR DESCRIPTION
Default `REFLECT_EVERY_N` 3 → 10. The capture window is watermark-delimited, so each reflection now receives the full 10-turn window — fewer, richer episodes and ~3x fewer reflector spawns. Still overridable via `AUTOHARNESS_REFLECT_EVERY_N`.

All 290 tests pass (tests assert relationships, not the absolute value).

🤖 Generated with [Claude Code](https://claude.com/claude-code)