### PR TITLE
chore: bump version to 0.3.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autoharness",
-  "version": "0.2.11",
+  "version": "0.3.0",
   "description": "Per-symbol maintenance optimizer for an agent's skill layer — learns skills from real runs and keeps them by adherence in use, not by an offline eval score.",
   "author": { "name": "Tigerless Labs" },
   "homepage": "https://github.com/tigerless-labs/autoharness",


### PR DESCRIPTION
Version bump for behavioral changes merged since 0.2.11:

- **PR #73** — MNG numerator counts `Read` into managed skill dirs (Skill-tool-only counting measured ~0 in practice, E8)
- **PR #74** — graduation review: a full probation with zero use is archived, never enters the mature pool
- **PR #75** — reflect cadence 3 → 10 turns per watermark window

Minor bump: #73+#74 activate the MNG lifecycle as a working feature class (usage-truthful numerator + the probation boundary rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)