### PR TITLE
chore: gitignore docs/research-loom-en and design-concepts zip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ dev_skill/
 # dev-internal (lives on the dev branch, excluded from the public release)
 CLAUDE.md
 docs/research-loom/
+docs/research-loom-en/
+autoharness-design-concepts-en.zip
 docs/plans/
 docs/TODO.md
 docs/testing.md


### PR DESCRIPTION
Same dev-internal treatment as the Chinese `docs/research-loom/`: the English tree and its packaged zip stay local, out of the public release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)