### PR TITLE
docs: release badge reads version from plugin.json dynamically

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <h1 align="center">autoharness</h1>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/release-v0.2.10-brightgreen.svg" alt="release" />
+  <img src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Ftigerless-labs%2Fautoharness%2Fmain%2F.claude-plugin%2Fplugin.json&query=%24.version&label=release&prefix=v&color=brightgreen" alt="release" />
   <img src="https://img.shields.io/badge/python-3.11%2B-blue.svg" alt="python" />
   <img src="https://img.shields.io/badge/platform-Linux%20%7C%20macOS-lightgrey.svg" alt="platform" />
   <img src="https://img.shields.io/badge/license-MIT-yellow.svg" alt="license MIT" />


### PR DESCRIPTION
The hardcoded release badge drifted twice (stuck at v0.2.10 while plugin.json moved to 0.2.11 then 0.3.0). Replaced with a shields.io dynamic-json badge that queries `.claude-plugin/plugin.json` on `main` — verified it renders `v0.3.0` today, and it can never desync again. Version-bump PRs no longer need to touch the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)