### PR TITLE
feat: periodic consolidation pass (curator)

### DIFF
--- a/agents/curator.md
+++ b/agents/curator.md
@@ -1,0 +1,51 @@
+---
+name: curator
+description: Periodic consolidation pass — fold narrow agent-created skills into class-level umbrellas. Proposes intents only, never writes to disk.
+tools: Read, Grep, Glob, mcp__plugin_autoharness_stage_skill__stage_skill
+model: haiku
+---
+
+You run periodically as autoharness' background skill CURATOR. This is an **umbrella-building consolidation pass**, not a passive audit and not a duplicate-finder. The reflector accumulates narrow, session-shaped skills eagerly; your job is to fold them into a smaller set of **class-level** skills an agent can actually discover.
+
+The goal of the library is a set of class-level instructions and experiential knowledge. Hundreds of narrow skills, each capturing one session's specific fix, is a **failure** of the library, not a feature — an agent matches skills on descriptions, and one broad umbrella with labeled subsections is more discoverable than five narrow siblings, not less. The right target shape is class-level skills with rich SKILL.md bodies plus `references/`, `templates/`, and `scripts/` subfiles for session-specific detail — never one-session-one-skill micro-entries.
+
+## What you are given (do not go fetch it)
+
+Your input already contains a description index of every **agent-created** skill across both layers (`global` and `project`), as `name [layer]: description`, plus the authoring + format spec that merged skills must satisfy. The index is already filtered to your members — you never see native / user / external skills, and must never create or name one. Use `Read` / `Grep` / `Glob` to open a candidate's full body and subfiles before you fold it; the index and spec are injected, never reconstruct them with tools.
+
+## You only ever propose
+
+Your single write face is `stage_skill`, which appends one proposal to a queue — it does **not** land anything. A separate deterministic promoter validates and writes, and it rejects any change to a skill that is not `created_by:agent`, so your membership boundary is enforced downstream too. Describe each change as an intent and stage it; never output a SKILL.md as prose — a textual description creates nothing.
+
+## Hard rules — do not violate
+
+1. **Only touch agent-created skills.** The index is your entire universe. Never resurrect, name, or absorb into a native / user skill.
+2. **Never destroy.** A `delete` intent **archives** the skill — moves its directory out of the live tree — which is recoverable. That is your maximum destructive action; there is no hard delete.
+3. **Do not use usage counts to decide.** The counters are new and mostly zero; `use=0` is absence of evidence, not a reason to merge and not a reason to prune. Judge overlap on **content**. Retirement by rate or age is the lifecycle layer's job — you only consolidate.
+4. **Pairwise distinctness is the wrong bar.** Never reject a merge because "each skill has a distinct trigger." The right question is: **would a maintainer write these as N separate skills, or as one skill with N labeled subsections?** When the answer is the latter, merge.
+
+## How to work
+
+1. Scan the full index. Identify **prefix clusters** — skills sharing a first word or domain keyword (`auth-*`, `widget-*`, `deploy-*`, …). Expect several.
+2. For each cluster with 2+ members, do not ask "do these overlap?" — ask **"what umbrella class do these all serve? Would a maintainer name that class and write one skill for it?"** If yes, pick or create the umbrella and absorb the siblings.
+3. Consolidate one of three ways per cluster:
+   - **Merge into an existing umbrella** — one member is already broad enough. `patch` it to add a labeled subsection for each sibling's unique insight, then `delete` each absorbed sibling.
+   - **Create a new umbrella** — no member is broad enough. `create` a class-level skill whose body covers the shared workflow with short labeled subsections, then `delete` the now-absorbed narrow siblings.
+   - **Demote to a subfile** — a sibling holds narrow-but-valuable session detail. Fold it into the umbrella's `references/<topic>.md` (session-specific detail, condensed knowledge banks), `templates/<name>.<ext>` (starter files to copy), or `scripts/<name>.<ext>` (re-runnable actions) by carrying it in the umbrella's `files`, then `delete` the old sibling.
+4. Also flag skills whose **name is too narrow** — a file path, an error string, a one-session artifact. These almost always belong as a subsection or subfile under a class-level umbrella.
+
+## Package integrity — not optional
+
+Before you fold a skill, inspect it as a **complete directory**, not just SKILL.md. If it carries `references/` / `templates/` / `scripts/` / `assets/`, or its body links to them, do not flatten only its SKILL.md into the umbrella. Either re-home every needed subfile into the umbrella's own support directories (carry them in `files`) and rewrite the pointers to the new paths, or leave the skill standalone. Never leave an absorbed skill's instructions pointing at files left behind under the old directory. `references/evidence-*` files are promoter-owned provenance — never carry or remove them.
+
+## Staging the merge (call `stage_skill`)
+
+- `patch` the umbrella: `old_string` → `new_string` (the `old_string` must match the live body uniquely). Add one labeled subsection per absorbed sibling.
+- `create` a new umbrella: the **full** `SKILL.md` body satisfying the spec, plus `level` — repo-specific (this codebase, its paths, stack) → `project`; a user preference or general technique → `global`; unsure → `project`. A `global` skill and its subfiles must carry no repo-local identifiers.
+- Carry demoted detail as `files` (`references/…` / `templates/…` / `scripts/…`); every subfile must be pointed at from the body or the promoter rejects it. Drop a stale subfile with `remove_file` after patching its pointer out of the body.
+- `delete` each absorbed sibling to archive it.
+- `reason` and `evidence` are required on every intent. `evidence` must be a verbatim slice — cite the overlapping index entries that triggered the merge (that citation is the absorbed-into signal; the LED records the provenance).
+
+## Keep, and iterate
+
+`keep` is legitimate **only** when a skill is already a class-level umbrella and no merge would improve discoverability. "Narrow but distinct from its siblings" is not a reason to keep — it is a reason to move it under an umbrella as a subsection or subfile. After one round, scan the remaining set for the **next umbrella** opportunity; iterate — don't stop after a few merges. When the library holds no more clusters worth folding, stage nothing and stop.

--- a/src/autoharness/config.py
+++ b/src/autoharness/config.py
@@ -19,6 +19,7 @@ def _int_env(name, default):
 
 
 REFLECT_EVERY_N = _int_env("AUTOHARNESS_REFLECT_EVERY_N", 10)  # trigger cadence; the window itself is watermark-delimited (capture)
+CONSOLIDATE_EVERY_N = _int_env("AUTOHARNESS_CONSOLIDATE_EVERY_N", 50)  # ponytail: placeholder, calibrate in experiments/; curator (content-level merge) beat, sparser than reflection (mirrors REFLECT_EVERY_N)
 
 # raw-capture byte caps (ponytail: placeholders, calibrate in experiments/): per transcript record,
 # and per handoff window (tail kept) — bound tool dumps / base64 away from the child context.
@@ -48,6 +49,7 @@ FORMAT_SPEC = _LIB / "format_spec.md"            # #416 single source for author
 CHILD_SESSION_ENV = "AUTOHARNESS_CHILD_SESSION"  # recursion-guard signal: set ONLY by spawn, read by CAP hooks (single source). Must be autoharness-owned: the host sets CLAUDE_CODE_CHILD_SESSION on every hook subprocess, so reusing it would gate every top-level turn.
 
 REFLECTOR_AGENT = "autoharness:reflector"  # the --agent reference for spawn (plugin namespace, Phase 0 resolution pending live test)
+CURATOR_AGENT = "autoharness:curator"      # the --agent reference for the periodic consolidation pass (same spawn chain as reflector)
 CLAUDE_BIN = "claude"                       # the child-session executable for spawn; PATH resolution, overridable in tests
 RUN_ID_ENV = "AUTOHARNESS_RUN_ID"           # spawn injects the intent-queue run_id into the child session via env (read by stage_skill)
 PROJECT_ROOT_ENV = "AUTOHARNESS_PROJECT_ROOT"  # same: repo root (where the queue is persisted)

--- a/src/autoharness/hook/dispatch.py
+++ b/src/autoharness/hook/dispatch.py
@@ -38,6 +38,11 @@ def _run_id(result):
     return f"{sid}-{result.get('count', 0)}"
 
 
+def _curate_run_id(event, pcount):
+    sid = _SANITIZE.sub("", str(event.get("session_id") or "")) or "run"
+    return f"{sid}-c{pcount}"  # keyed on the monotonic request count → unique per curator launch
+
+
 def _is_reflector(event):
     at = str(event.get("agent_type") or "")
     return at == config.REFLECTOR_AGENT or at.endswith("reflector")
@@ -60,11 +65,21 @@ def _reflect(event, result, roots, launch=None):
     (launch or _detached_launch)(transcript_path, result.get("session_id", ""), _run_id(result), roots)
 
 
-def dispatch(event, *, roots=None, reflect=None):
+def _consolidate_launch(run_id, roots):
+    subprocess.Popen(  # host-detach: same fire-and-forget as reflection; the curator reads the library, not the transcript
+        [sys.executable, "-m", "autoharness.hook.spawn", "--curate", run_id,
+         str(roots[layer.PROJECT]), str(roots[layer.GLOBAL])],
+        start_new_session=True, stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+    )
+
+
+def dispatch(event, *, roots=None, reflect=None, consolidate=None):
     name = event.get("hook_event_name")
     roots = _roots(roots)
     proot = roots.get(layer.PROJECT)
     fire = reflect or _reflect
+    curate = consolidate or _consolidate_launch
     try:
         if name == "SessionStart":
             return {"handled": name, "result": on_session_start.on_session_start(event, roots=roots)}
@@ -72,10 +87,12 @@ def dispatch(event, *, roots=None, reflect=None):
             if os.environ.get(config.CHILD_SESSION_ENV):
                 return {"handled": name, "result": {"triggered": False, "reason": "recursion_guard"}}
             counters.bump_request(layer.GLOBAL, roots.get(layer.GLOBAL))  # MNG denominator (per turn)
-            counters.bump_request(layer.PROJECT, proot)
+            pcount = counters.bump_request(layer.PROJECT, proot)
             result = on_stop.on_stop(event, root=proot)
             if result.get("triggered"):
                 fire(event, result, roots)
+            if config.CONSOLIDATE_EVERY_N and pcount % config.CONSOLIDATE_EVERY_N == 0:
+                curate(_curate_run_id(event, pcount), roots)  # periodic content-level merge pass (rarer than reflection)
             return {"handled": name, "result": result}
         if name == "SessionEnd":
             result = on_session_end.on_session_end(event, root=proot)

--- a/src/autoharness/hook/spawn.py
+++ b/src/autoharness/hook/spawn.py
@@ -17,19 +17,23 @@ from pathlib import Path
 
 from autoharness import config
 from autoharness.hook import capture, promoter
-from autoharness.lib import counters, layer, skill_store, validate
+from autoharness.lib import counters, layer, sidecar, skill_store, validate
 
 
-def description_index(roots=None):
+def description_index(roots=None, *, agent_only=False):
     roots = roots or {}
     lines = []
     for lyr in layer.LAYERS:
-        skills = layer.skills_dir(lyr, roots.get(lyr))
+        root = roots.get(lyr)
+        skills = layer.skills_dir(lyr, root)
         if not skills.exists():
             continue
         for path in sorted(skills.glob(f"*/{skill_store.SKILL_FILE}")):
+            symbol = path.parent.name
+            if agent_only and not sidecar.is_agent_created(lyr, symbol, root):
+                continue  # curator only ever sees its own skills; native/user stay out of the pool
             fm = validate._frontmatter(path.read_text()) or {}
-            name = fm.get("name") or path.parent.name
+            name = fm.get("name") or symbol
             desc = fm.get("description") or "(no description)"
             lines.append(f"- {name} [{lyr}]: {desc}")
     return "\n".join(lines) if lines else "(no live skills yet)"
@@ -45,6 +49,15 @@ def build_bundle(window, index, spec, digest=""):
         + "# Episode window (redacted)\n\n" + window
         + "\n\n# Existing skills (compare-first: dedupe / patch / where)\n\n" + index
         + "\n\n# Authoring + format spec (write to satisfy this)\n\n" + spec + "\n"
+    )
+
+
+def build_curator_bundle(index, spec):
+    # The curator consolidates the whole agent-authored library, not one episode — so no window.
+    return (
+        "# Agent-authored skills (consolidate: merge narrow siblings into class-level umbrellas)\n\n"
+        + index
+        + "\n\n# Authoring + format spec (merged skills must satisfy this)\n\n" + spec + "\n"
     )
 
 
@@ -84,8 +97,26 @@ def run(window_text, run_id, *, roots, repo_name=None, agent=None, claude_bin=No
     return promoter.drain(run_id, roots=roots, repo_name=repo_name)
 
 
+def run_curator(run_id, *, roots, repo_name=None, agent=None, claude_bin=None,
+                spec_path=None, spawn_fn=None):
+    roots = roots or {}
+    spec = (spec_path or config.FORMAT_SPEC).read_text()
+    bundle = build_curator_bundle(description_index(roots, agent_only=True), spec)
+
+    argv = build_command(agent=agent or config.CURATOR_AGENT,
+                         claude_bin=claude_bin or config.CLAUDE_BIN)
+    env = child_env(run_id, roots.get(layer.PROJECT))
+    (spawn_fn or _detached_spawn)(argv, env, bundle)
+
+    return promoter.drain(run_id, roots=roots, repo_name=repo_name)
+
+
 def main(argv=None):
-    transcript_path, session_id, run_id, proot, groot = argv if argv is not None else sys.argv[1:]
+    argv = list(sys.argv[1:] if argv is None else argv)
+    if argv and argv[0] == "--curate":
+        run_id, proot, groot = argv[1:]
+        return run_curator(run_id, roots={layer.PROJECT: Path(proot), layer.GLOBAL: Path(groot)})
+    transcript_path, session_id, run_id, proot, groot = argv
     roots = {layer.PROJECT: Path(proot), layer.GLOBAL: Path(groot)}
     offset = counters.session_offset(session_id, roots[layer.PROJECT])
     window_text, new_offset = capture.window(transcript_path, offset)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -8,6 +8,27 @@ def test_cadence_positive():
     assert isinstance(config.REFLECT_EVERY_N, int) and config.REFLECT_EVERY_N > 0
 
 
+def test_consolidate_cadence_sparser_than_reflect():
+    # curation runs periodically like reflection but rarer — merging the library is a coarser beat
+    assert isinstance(config.CONSOLIDATE_EVERY_N, int)
+    assert config.CONSOLIDATE_EVERY_N > config.REFLECT_EVERY_N
+
+
+def test_curator_agent_named_and_distinct():
+    assert config.CURATOR_AGENT and isinstance(config.CURATOR_AGENT, str)
+    assert config.CURATOR_AGENT != config.REFLECTOR_AGENT
+
+
+def test_env_overrides_consolidate_cadence(monkeypatch):
+    monkeypatch.setenv("AUTOHARNESS_CONSOLIDATE_EVERY_N", "7")
+    importlib.reload(config)
+    try:
+        assert config.CONSOLIDATE_EVERY_N == 7
+    finally:
+        monkeypatch.undo()
+        importlib.reload(config)
+
+
 def test_layered_knobs_cover_both_layers_and_positive():
     for knob in (config.MATURITY_THRESHOLD, config.CAPACITY):
         assert set(knob) == set(layer.LAYERS)

--- a/tests/test_curator_agent.py
+++ b/tests/test_curator_agent.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+
+from autoharness.lib import validate
+
+AGENT = Path(__file__).resolve().parents[1] / "agents" / "curator.md"
+
+
+def test_curator_frontmatter_present():
+    fm = validate._frontmatter(AGENT.read_text())
+    assert fm is not None and fm.get("name") and fm.get("model")
+
+
+def test_curator_tools_are_least_privilege():
+    fm = validate._frontmatter(AGENT.read_text())
+    tools = fm["tools"]
+    for allowed in ("Read", "Grep", "Glob"):
+        assert allowed in tools
+    # same emit-only write face as the reflector — propose intents, never touch the live tree
+    assert "mcp__plugin_autoharness_stage_skill__stage_skill" in tools
+    for forbidden in ("Write", "Edit", "Bash"):
+        assert forbidden not in tools
+
+
+def test_curator_ports_umbrella_levers():
+    body = AGENT.read_text().lower()
+    for lever in ("umbrella", "class-level", "prefix", "references/", "templates/", "scripts/"):
+        assert lever in body
+
+
+def test_curator_teaches_three_ways_to_consolidate():
+    body = AGENT.read_text().lower()
+    assert "existing umbrella" in body   # (a) merge into an already-broad member
+    assert "new umbrella" in body        # (b) create a fresh umbrella
+    assert "demote" in body              # (c) demote narrow detail into support subfiles
+
+
+def test_curator_delete_is_archive_not_destruction():
+    body = AGENT.read_text().lower()
+    assert "archive" in body
+    assert "recoverable" in body  # delete stages an archive move-out, never a hard delete
+
+
+def test_curator_only_touches_agent_created():
+    body = AGENT.read_text().lower()
+    assert "created_by:agent" in body or "agent-created" in body  # native/user skills are out of pool
+
+
+def test_curator_is_iterative():
+    body = AGENT.read_text().lower()
+    assert "iterate" in body or "next umbrella" in body
+
+
+def test_curator_judges_by_maintainer_bar_not_pairwise():
+    body = AGENT.read_text().lower()
+    assert "maintainer" in body  # "would a maintainer write N skills or one with N subsections?"

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -92,6 +92,41 @@ def test_real_onstop_triggers_at_cadence(tmp_path):
     assert len(seen) == 1 and seen[0]["window_n"] == config.REFLECT_EVERY_N
 
 
+def test_curate_run_id_sanitized_and_unique_per_count():
+    assert dispatch._curate_run_id({"session_id": "abc/1"}, 5) == "abc1-c5"
+
+
+def test_curator_fires_at_consolidate_cadence(tmp_path, monkeypatch):
+    monkeypatch.setattr(dispatch.config, "CONSOLIDATE_EVERY_N", 3)
+    roots = _roots(tmp_path)
+    fired = []
+    for _ in range(3):
+        dispatch.dispatch({"hook_event_name": "Stop", "session_id": "s1", "transcript_path": "/t.jsonl"},
+                          roots=roots, reflect=lambda *a: None,
+                          consolidate=lambda run_id, r: fired.append(run_id))
+    assert fired == ["s1-c3"]  # once, on the turn the request counter hits a multiple of N
+
+
+def test_curator_not_fired_off_cadence(tmp_path, monkeypatch):
+    monkeypatch.setattr(dispatch.config, "CONSOLIDATE_EVERY_N", 3)
+    roots = _roots(tmp_path)
+    fired = []
+    for _ in range(2):
+        dispatch.dispatch({"hook_event_name": "Stop", "session_id": "s1"},
+                          roots=roots, reflect=lambda *a: None,
+                          consolidate=lambda run_id, r: fired.append(run_id))
+    assert fired == []
+
+
+def test_curator_not_fired_in_child_session(tmp_path, monkeypatch):
+    monkeypatch.setenv(config.CHILD_SESSION_ENV, "1")
+    monkeypatch.setattr(dispatch.config, "CONSOLIDATE_EVERY_N", 1)  # would fire every turn if unguarded
+    fired = []
+    dispatch.dispatch({"hook_event_name": "Stop", "session_id": "s1"}, roots=_roots(tmp_path),
+                      reflect=lambda *a: None, consolidate=lambda run_id, r: fired.append(run_id))
+    assert fired == []  # recursion guard: a curator/reflector child never spawns another curator
+
+
 def test_untriggered_stop_does_not_reflect(tmp_path, monkeypatch):
     monkeypatch.setattr(dispatch.on_stop, "on_stop", lambda e, **k: {"triggered": False, "count": 1})
     calls = []

--- a/tests/test_plugin_manifest.py
+++ b/tests/test_plugin_manifest.py
@@ -50,3 +50,7 @@ def test_marketplace_lists_this_plugin():
 
 def test_agents_reflector_present():
     assert (ROOT / "agents/reflector.md").exists()
+
+
+def test_agents_curator_present():
+    assert (ROOT / "agents/curator.md").exists()  # the periodic consolidation pass agent

--- a/tests/test_spawn.py
+++ b/tests/test_spawn.py
@@ -119,6 +119,78 @@ def test_run_feeds_bundle_and_drains_no_handoff_persisted(tmp_path):
     assert not (layer.state_dir(layer.PROJECT, roots["project"]) / "handoff").exists()  # bundle lives only in the pipe
 
 
+# --- curator: periodic consolidation pass (reuses the reflector spawn chain) ---
+
+def test_description_index_agent_only_filters_native(tmp_path):
+    roots = _roots(tmp_path)
+    skill_store.write_body("project", "native1", GOOD.format(n="native1", d="native"), roots["project"])
+    skill_store.write_body("project", "agent1", GOOD.format(n="agent1", d="agent made"), roots["project"])
+    sidecar.create("project", "agent1", 0, roots["project"])  # created_by:agent
+    idx = spawn.description_index(roots, agent_only=True)
+    assert "agent1" in idx
+    assert "native1" not in idx  # the curator only ever sees its own skills
+
+
+def test_curator_bundle_has_index_and_spec():
+    b = spawn.build_curator_bundle("INDEX_MARK", "SPEC_MARK")
+    assert "INDEX_MARK" in b and "SPEC_MARK" in b
+
+
+def test_curate_main_parses_argv_and_runs(tmp_path, monkeypatch):
+    seen = {}
+    monkeypatch.setattr(spawn, "run_curator",
+                        lambda rid, **k: seen.update(rid=rid, roots=k["roots"]))
+    spawn.main(["--curate", "run-c9", str(tmp_path / "p"), str(tmp_path / "g")])
+    assert seen["rid"] == "run-c9"
+    assert seen["roots"][layer.PROJECT] == tmp_path / "p"
+    assert seen["roots"][layer.GLOBAL] == tmp_path / "g"
+
+
+def test_run_curator_lands_merge_and_archives_narrow(tmp_path):
+    roots = _roots(tmp_path)
+    root = roots["project"]
+    skill_store.write_body("project", "widgets", GOOD.format(n="widgets", d="widget umbrella"), root)
+    sidecar.create("project", "widgets", 0, root)
+    skill_store.write_body("project", "widget-delta", GOOD.format(n="widget-delta", d="narrow delta"), root)
+    sidecar.create("project", "widget-delta", 0, root)
+
+    def fake_curator(argv, env, bundle):
+        from autoharness.lib import intent_queue
+        rid = env[config.RUN_ID_ENV]
+        intent_queue.append(rid, {"action": "patch", "name": "widgets",
+                                  "old_string": "body", "new_string": "body\n## delta\nabsorbed",
+                                  "reason": "fold widget-delta into the widgets umbrella",
+                                  "evidence": "widgets [project] / widget-delta [project]"}, root)
+        intent_queue.append(rid, {"action": "delete", "name": "widget-delta",
+                                  "reason": "absorbed into widgets umbrella",
+                                  "evidence": "widgets [project] / widget-delta [project]"}, root)
+
+    verdicts = spawn.run_curator("run-c", roots=roots, spec_path=config.FORMAT_SPEC, spawn_fn=fake_curator)
+    assert [v["ok"] for v in verdicts] == [True, True]
+    assert "absorbed" in skill_store.read_body("project", "widgets", root)
+    assert skill_store.read_body("project", "widget-delta", root) is None  # moved out of the live tree
+    assert (layer.archive_dir("project", root) / "widget-delta").exists()  # archive is recoverable
+    assert any(e["action"] == "patch" for e in ledger.read("project", "widgets", root))
+
+
+def test_run_curator_cannot_touch_native_skill(tmp_path):
+    # red team: the shared promoter membership guard rejects any modify on a non-agent skill
+    roots = _roots(tmp_path)
+    root = roots["project"]
+    skill_store.write_body("project", "native", GOOD.format(n="native", d="native"), root)  # no sidecar
+
+    def fake_curator(argv, env, bundle):
+        from autoharness.lib import intent_queue
+        intent_queue.append(env[config.RUN_ID_ENV],
+                            {"action": "delete", "name": "native",
+                             "reason": "tried to prune a native skill", "evidence": "native [project]"}, root)
+
+    verdicts = spawn.run_curator("run-r", roots=roots, spec_path=config.FORMAT_SPEC, spawn_fn=fake_curator)
+    assert verdicts and verdicts[0]["ok"] is False
+    assert "self_produced" in str(verdicts[0]["findings"])
+    assert skill_store.read_body("project", "native", root) is not None  # native untouched
+
+
 def _fake_reflector_script(tmp_path):
     script = tmp_path / "fake_reflector.py"
     script.write_text(
@@ -154,3 +226,44 @@ def test_system_fake_reflector_cross_process_lands(tmp_path, monkeypatch):
     assert sidecar.is_agent_created("project", "learned", root)
     led = ledger.read("project", "learned", root)
     assert len(led) == 1 and led[0]["action"] == "create"
+
+
+def _fake_curator_script(tmp_path):
+    script = tmp_path / "fake_curator.py"
+    script.write_text(
+        "#!/usr/bin/env python3\n"
+        "import os, sys\n"
+        "from pathlib import Path\n"
+        "from autoharness import config\n"
+        "from autoharness.stage_skill import server\n"
+        "sys.stdin.read()\n"  # consume the curator bundle (proves it arrived on stdin)
+        "run_id = os.environ[config.RUN_ID_ENV]\n"
+        "root = Path(os.environ[config.PROJECT_ROOT_ENV])\n"
+        "ev = 'widgets [project] / widget-delta [project]'\n"
+        "server.stage({'action': 'patch', 'name': 'widgets', 'old_string': 'body',\n"
+        "              'new_string': 'body\\n## delta\\nabsorbed', 'reason': 'fold into umbrella',\n"
+        "              'evidence': ev}, run_id=run_id, root=root)\n"
+        "server.stage({'action': 'delete', 'name': 'widget-delta',\n"
+        "              'reason': 'absorbed into widgets', 'evidence': ev}, run_id=run_id, root=root)\n"
+        "sys.exit(0)\n"
+    )
+    script.chmod(0o755)
+    return script
+
+
+def test_system_fake_curator_cross_process_merges(tmp_path, monkeypatch):
+    monkeypatch.setenv("PYTHONPATH", _SRC)  # child subprocess must import autoharness
+    roots = _roots(tmp_path)
+    root = roots["project"]
+    for n, d in (("widgets", "widget umbrella"), ("widget-delta", "narrow delta")):
+        skill_store.write_body("project", n, GOOD.format(n=n, d=d), root)
+        sidecar.create("project", n, 0, root)
+    script = _fake_curator_script(tmp_path)
+
+    verdicts = spawn.run_curator("run-csys", roots=roots, repo_name="myrepo",
+                                 claude_bin=str(script), spec_path=config.FORMAT_SPEC)
+
+    assert [v["ok"] for v in verdicts] == [True, True]
+    assert "absorbed" in skill_store.read_body("project", "widgets", root)
+    assert skill_store.read_body("project", "widget-delta", root) is None  # archived out of the live tree
+    assert (layer.archive_dir("project", root) / "widget-delta").exists()


### PR DESCRIPTION
## What

Adds a background **curator** — a periodic content-level consolidation pass that folds narrow, session-shaped agent skills into **class-level umbrellas**. This is the organ autoharness was missing: the eager reflector distill can't do cross-episode/cross-skill consolidation (it's biased to capture-liberally and only sees the current window), and MNG only retires by rate/capacity, never merges by content.

Motivated by the lara one-week empirical finding: agent-skill reuse ≈ 0, root cause is auto-distilled skills being the wrong *shape* for the `Skill`-tool pull model. Hermes closes this with a separate curator organ (`CURATOR_REVIEW_PROMPT`); this ports that lever.

## How

- **config**: `CONSOLIDATE_EVERY_N` (default 50, `AUTOHARNESS_*` overridable) + `CURATOR_AGENT`.
- **dispatch**: on `Stop`, when project `requests % N == 0`, fire a detached curator spawn beside the reflector trigger — same Stop-counter modulo pattern, sparser beat. Shared child-session recursion guard; zero wall-clock.
- **spawn**: `run_curator` reuses the reflector spawn chain (`build_command` / `child_env` / `promoter.drain`); `build_curator_bundle` feeds the **agent-only** description index + format spec (no episode window). `description_index` gains an `agent_only` filter so the curator only ever sees `created_by:agent` skills.
- **agents/curator.md**: umbrella-building prompt comprehensively ported from Hermes `CURATOR_REVIEW_PROMPT`, adapted to our architecture — `stage_skill` (propose-only) instead of `skill_manage`, `files`+`remove_file` instead of `terminal mv`, LED `reason/evidence` instead of `absorbed_into`; Hermes' YAML block / staleness-pruning / cron / dry-run dropped (retirement stays MNG's job).
- Membership + archive-not-delete are enforced by the **shared promoter guard** (`self_produced` reject on any modify of a non-agent skill) — no new enforcement code.

## Division of labor
Curation (merge by content) and MNG (retire by rate) are two independent periodic activities: both only archive, both reversible, both touch only agent skills, but triggers/criteria/effects don't overlap.

## Tests
Cadence (config + dispatch), agent-only index filter, in-process **and** cross-process merge landing (patch umbrella + archive sibling via a real subprocess), red-team native-skill reject, curator-prompt levers, manifest parity. Full suite: 312 passed, ruff clean.

## Follow-up (not in this PR)
- Live-host verification of the `--curate` trigger + curator agent registration (shares the reflector's already-verified spawn chain; only the argv branch + agent are new).
- Priority is gated by experiment **E9** (surfacing vs relevance) — if the real problem is host surfacing, this pass helps discoverability but isn't the whole fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)