### PR TITLE
chore: bump version to 0.3.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autoharness",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Per-symbol maintenance optimizer for an agent's skill layer — learns skills from real runs and keeps them by adherence in use, not by an offline eval score.",
   "author": { "name": "Tigerless Labs" },
   "homepage": "https://github.com/tigerless-labs/autoharness",


### PR DESCRIPTION
Patch bump 0.3.0 → 0.3.1 for the periodic consolidation pass / curator (PR #81, merged). Version lives only in `.claude-plugin/plugin.json`; the README release badge reads it dynamically.