### PR TITLE
docs: fix plugin update command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,15 +43,22 @@ background. Cadence and lifecycle thresholds are tunable — see [Configuration]
 
 ### Update
 
+Update from a terminal — the command needs the **full `plugin@marketplace` id** (a bare
+`autoharness` fails with `Plugin "autoharness" not found`):
+
 ```
-/plugin marketplace update autoharness              # pull the latest release
-/plugin update autoharness                          # update the installed copy
-/reload-plugins                                     # apply in the running session
+claude plugin update autoharness@autoharness
 ```
 
-`/reload-plugins` re-arms the hooks and the MCP server in place; restarting Claude Code works too.
-The installed copy is cached by the version in `plugin.json`; releases always bump it, which is
-what makes the update take effect.
+Then **restart Claude Code** to apply — a version bump is a fresh cached copy, not a hot reload.
+
+If it reports `already at the latest version` when a newer one shipped, your local catalog is
+stale; refresh it first with `claude plugin marketplace update autoharness`, then update again.
+
+Third-party marketplaces have auto-update **off** by default. To make future releases hands-off,
+enable it once: `/plugin` → **Marketplaces** → **autoharness** → **Enable auto-update**. The
+installed copy is cached by the `version` in `plugin.json`; a release reaches users only when that
+field is bumped.
 
 ### Uninstall
 


### PR DESCRIPTION
The README's Update section shipped a broken command. Verified against Claude Code v2.1.218:

- \`claude plugin update autoharness\` (bare name) fails \`Plugin "autoharness" not found\` — plugins are keyed by the full \`plugin@marketplace\` id in the installed/available tables, and bare-name resolution isn't implemented for \`update\` (only \`enable\`/\`disable\` got it in v2.1.195; the CLI \`--help\` claims bare names work but they don't). The working command is \`claude plugin update autoharness@autoharness\`.
- A version bump is a fresh cached copy, not a hot reload — applying it needs a **restart**, not \`/reload-plugins\` (the command itself prints "Restart to apply changes").
- Third-party marketplaces have auto-update **off** by default; documented how to enable it once.

Empirically confirmed: bare name still 404s post-refresh/post-update, qualified id updates 0.3.0 → 0.3.1 cleanly.