### PR TITLE
docs(readme): keep the badge row on one line

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,7 @@
 <p align="center"><strong>Self-Learning Skills for Claude Code</strong></p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Ftigerless-labs%2Fautoharness%2Fmain%2F.claude-plugin%2Fplugin.json&query=%24.version&label=release&prefix=v&color=brightgreen" alt="release" />
-  <img src="https://img.shields.io/badge/python-3.11%2B-blue.svg" alt="python" />
-  <img src="https://img.shields.io/badge/platform-Linux%20%7C%20macOS-lightgrey.svg" alt="platform" />
-  <img src="https://img.shields.io/badge/license-MIT-yellow.svg" alt="license MIT" />
+  <img src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Ftigerless-labs%2Fautoharness%2Fmain%2F.claude-plugin%2Fplugin.json&query=%24.version&label=release&prefix=v&color=brightgreen" alt="release" /> <img src="https://img.shields.io/badge/python-3.11%2B-blue.svg" alt="python" /> <img src="https://img.shields.io/badge/platform-Linux%20%7C%20macOS-lightgrey.svg" alt="platform" /> <img src="https://img.shields.io/badge/license-MIT-yellow.svg" alt="license MIT" />
 </p>
 
 **autoharness is a self-learning skill layer for Claude Code.** It **learns** skills from your real


### PR DESCRIPTION
The shields badges each sat on their own source line inside `<p align="center">`. Renderers that turn a newline inside a raw HTML block into a line break stacked them into a vertical column instead of a row.

Joined onto a single line — renders horizontally everywhere; badge URLs and alt text unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)