### PR TITLE
chore: bump version to 0.3.3

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autoharness",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Per-symbol maintenance optimizer for an agent's skill layer — learns skills from real runs and keeps them by adherence in use, not by an offline eval score.",
   "author": { "name": "Tigerless Labs" },
   "homepage": "https://github.com/tigerless-labs/autoharness",


### PR DESCRIPTION
Ships the four-element description recipe (#88) to installed copies — the plugin cache keys on `plugin.json` version, so the spec change reaches reflectors only after a bump.