### PR TITLE
Phase 14: the trigger cue must survive index truncation

### DIFF
--- a/skills/learn/SKILL.md
+++ b/skills/learn/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: learn
-description: Distill a reusable skill from the current session on demand. Use when the user says "/learn", "learn this", "记住这个做法", or asks to save/capture the workflow or lesson just worked through.
+description: Distills this session into a reusable skill. Use when the user says "/learn", "learn this", "记住这个做法", or asks to save or capture the workflow or lesson just worked through.
 category: general
 ---
 # Learn: distill this session into the skill library

--- a/src/autoharness/lib/format_spec.md
+++ b/src/autoharness/lib/format_spec.md
@@ -25,8 +25,11 @@ Optional, and worth setting:
 The host preloads every skill's `name` + `description` and picks among all of them by matching the
 user's request against the description. The description carries the whole selection signal; a body
 only matters after it has already fired. It is read twice over: in full by the host's own recall, and
-truncated to `INDEX_DESC_MAX_CHARS` in the injected index — so the distinguishing cue must come
-early, before the truncation point, not in a trailing clause. Write it to this shape:
+truncated to `INDEX_DESC_MAX_CHARS` in the injected index. **The trigger cue must fall inside that
+truncated prefix** — a `when` clause or a quoted phrase within the first `INDEX_DESC_MAX_CHARS`
+characters — or the promoter rejects the `create`/`update`: past the cut the description is half a
+sentence on the very recall surface this system builds. Lead with the cue, then the detail.
+(`patch` is exempt, so an existing description can still be repaired.) Write it to this shape:
 
     <verb phrase: what it does>. Use when <the situation>, or when the user mentions <the words
     they would type, every alias for the same thing>.

--- a/src/autoharness/lib/format_spec.md
+++ b/src/autoharness/lib/format_spec.md
@@ -59,8 +59,8 @@ One description straining to cover five distinct triggers → split into separat
 its own.
 
 **Enforced (a floor, not the standard):** the promoter rejects a `create`/`update` whose description
-carries no trigger cue — neither a `when` clause nor a quoted phrase — or exceeds
-`SKILL_DESC_MAX_CHARS`. That check is a crude proxy; passing it is not the same as satisfying the
+carries no trigger cue — neither a `when` clause nor a quoted phrase — whose cue falls past
+`INDEX_DESC_MAX_CHARS`, or which exceeds `SKILL_DESC_MAX_CHARS`. That check is a crude proxy; passing it is not the same as satisfying the
 four elements, and the judgment stays the author's.
 
 ## Structure (#416)

--- a/src/autoharness/lib/validate.py
+++ b/src/autoharness/lib/validate.py
@@ -37,6 +37,10 @@ _QUOTED_PHRASE = re.compile(r'"[^"]+"|\'[^\']+\'|`[^`]+`')
 _WHEN = re.compile(r"(?i)\bwhen")
 
 
+def _has_cue(text):
+    return bool(_WHEN.search(text) or _QUOTED_PHRASE.search(text))
+
+
 def _frontmatter(body):
     m = _FRONTMATTER.match(body)
     if not m:
@@ -65,10 +69,15 @@ def _description_findings(desc):
         findings.append(("description",
                          f"description is {len(desc)} chars (> {config.SKILL_DESC_MAX_CHARS}); "
                          "the host matches on it and truncates past the cap"))
-    if not (_WHEN.search(desc) or _QUOTED_PHRASE.search(desc)):
+    if not _has_cue(desc):
         findings.append(("trigger",
                          "description has no trigger cue: add 'use when …' and/or a literal phrase "
                          "the user would type — an abstract topic-label never fires"))
+    elif not _has_cue(desc[:config.INDEX_DESC_MAX_CHARS]):
+        findings.append(("trigger",
+                         f"the trigger cue lands past char {config.INDEX_DESC_MAX_CHARS}, where the "
+                         "session-start index truncates every line — on our own recall surface this "
+                         "description is half a sentence. Lead with the cue, then the detail"))
     return findings
 
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -123,6 +123,50 @@ def test_trigger_patch_exempt():
     assert "trigger" not in _families(v)
 
 
+def test_trigger_cue_must_survive_index_truncation():
+    # the self-injected index truncates each line to INDEX_DESC_MAX_CHARS, so a cue that only
+    # appears after that point leaves the skill as half a sentence on our own recall surface
+    from autoharness import config
+    late = "Handles the whole of the repository maintenance story " * 3 + "use when auditing."
+    assert len(late) > config.INDEX_DESC_MAX_CHARS
+    v = validate.validate(GOOD_INTENT, _desc_body(late))
+    assert not v["ok"] and "trigger" in _families(v)
+
+
+def test_trigger_cue_inside_the_index_prefix_passes():
+    from autoharness import config
+    early = "Use when auditing a repo. " + "Background detail that runs past the index budget. " * 3
+    assert len(early) > config.INDEX_DESC_MAX_CHARS  # long overall, cue still up front
+    assert "trigger" not in _families(validate.validate(GOOD_INTENT, _desc_body(early)))
+
+
+def test_trigger_cue_straddling_the_truncation_point_rejected():
+    # a cue the truncation cuts in half is not readable in the index either
+    from autoharness import config
+    pad = "x" * (config.INDEX_DESC_MAX_CHARS - 2) + " "  # the cue word starts one char before the cut
+    v = validate.validate(GOOD_INTENT, _desc_body(f"{pad}when auditing a repo."))
+    assert not v["ok"] and "trigger" in _families(v)
+
+
+def test_trigger_prefix_gate_exempts_patch():
+    # same reason the altitude cap exempts patch: an existing over-long description must stay fixable
+    from autoharness import config
+    late = "y" * config.INDEX_DESC_MAX_CHARS + " use when auditing a repo."
+    intent = {"action": "patch", "name": "foo", "reason": "r", "evidence": "e"}
+    v = validate.validate(intent, _desc_body(late), target_is_agent_created=True)
+    assert "trigger" not in _families(v)
+
+
+def test_trigger_prefix_gate_is_not_a_length_gate():
+    # the two description gates are independent: a long description with an early cue passes the
+    # prefix gate and is still bounded by SKILL_DESC_MAX_CHARS alone
+    from autoharness import config
+    ok_long = "Use when auditing. " + "z" * (config.SKILL_DESC_MAX_CHARS - 30)
+    assert "description" not in _families(validate.validate(GOOD_INTENT, _desc_body(ok_long)))
+    too_long = "Use when auditing. " + "z" * config.SKILL_DESC_MAX_CHARS
+    assert "description" in _families(validate.validate(GOOD_INTENT, _desc_body(too_long)))
+
+
 def test_description_over_length_rejected():
     from autoharness import config
     v = validate.validate(GOOD_INTENT, _desc_body("use when " + "x" * (config.SKILL_DESC_MAX_CHARS + 1)))


### PR DESCRIPTION
Roadmap Phase 14, from [category-lifecycle](docs/plans/category-lifecycle.md) C1b.

## Why

Reading hermes-agent's source turned up a hard gate we lacked: it refuses to create a skill whose description cannot survive its own index truncation (`_validate_frontmatter`, `new_skill` path — 60 chars, exactly the index budget), with the error text spelling out the reason: past the cut the index shows 57 chars + `...`, so a new skill must lead with its trigger.

We had the same truncation (`INDEX_DESC_MAX_CHARS`) and no gate. Our admission check was the host's 1024-char limit, so a cue could sit at char 900 — fully visible to the host's native recall, invisible on the recall surface this plugin builds for itself. That is the same failure family as lara's `calls≈0`: the description is the trigger, and half a trigger fires nothing.

## What it does, and what it deliberately does not copy

`create`/`update` are rejected when the cue (a `when` clause or a quoted phrase) falls outside the first `INDEX_DESC_MAX_CHARS` characters. `patch` is exempt, for the same reason the altitude cap is: an existing description has to stay repairable.

Not copied: Hermes's hard 60-char cap on the description itself. Its index is the only recall surface, so capping is coherent there. Ours is read twice — the host reads all of it, our index reads the prefix — so a total-length cap would weaken the first reader. Only the prefix is constrained; total length stays governed by `SKILL_DESC_MAX_CHARS`.

## Dogfood result

The gate rejected our own shipped `/learn` skill on its first run — its cue landed at char 62. Reworded to lead with it. That was the Phase 14 acceptance step (run the gate over existing descriptions before shipping it); one hit out of one authored skill, and the fix was a rewording, not a loosening.

386 tests (up from 381), ruff clean.