### PR TITLE
Phase 15: category writers, fail-open accounting, curator backfill

### DIFF
--- a/agents/curator.md
+++ b/agents/curator.md
@@ -45,8 +45,15 @@ Before you fold a skill, inspect it as a **complete directory**, not just SKILL.
 - Carry demoted detail as `files` (`references/…` / `templates/…` / `scripts/…`); every subfile must be pointed at from the body or the promoter rejects it. Drop a stale subfile with `remove_file` after patching its pointer out of the body.
 - `delete` each absorbed sibling to archive it — **always with `absorbed_into` set to the umbrella's name** (leave it empty only for a true retirement that nothing absorbed). The promoter verifies that umbrella is a live self-produced skill and rejects the whole intent if it is not, so a name you did not actually create or patch this run will fail closed.
 - When the umbrella's instructions contradict something an absorbed sibling said, resolve it in the `patch` rather than carrying both — a merged skill that argues with itself is worse than the two it replaced.
+- Every `create` and `update` body carries a frontmatter `category:` — the class of work the skill serves, one lowercase word or hyphenated phrase. An umbrella and everything it absorbs take the **same** category; a prefix cluster and a category are the same judgement seen twice.
 - `reason` and `evidence` are required on every intent. `evidence` must be a verbatim slice — cite the overlapping index entries that triggered the merge.
+
+## Backfill the category of what you keep
+
+The index every session opens with is grouped by `category`, so a library where everything sits in `general` is a flat list again — and nothing else in the system ever revisits that field. You are the only organ that does. So on every run, besides folding: for each skill you keep that has **no** category, or sits in `general` while plainly belonging to a cluster you can name, stage a `patch` that sets the field. One skill per intent, and backfill only what you are confident about — a wrong label is worse than `general`, which at least reads as "unfiled".
+
+Prefer a category already visible in the index over a new synonym for it; mint a new one only when nothing existing fits the class.
 
 ## Keep, and iterate
 
-`keep` is legitimate **only** when a skill is already a class-level umbrella and no merge would improve discoverability. "Narrow but distinct from its siblings" is not a reason to keep — it is a reason to move it under an umbrella as a subsection or subfile. After one round, scan the remaining set for the **next umbrella** opportunity; iterate — don't stop after a few merges. When the library holds no more clusters worth folding, stage nothing and stop.
+`keep` is legitimate **only** when a skill is already a class-level umbrella and no merge would improve discoverability. "Narrow but distinct from its siblings" is not a reason to keep — it is a reason to move it under an umbrella as a subsection or subfile. Sharing a category is not a reason to keep either: **the same category is not a reason not to merge** — filing two narrow skills under one label is bookkeeping, not consolidation, and the question stays "would a maintainer write these as N skills or as one with N subsections?" After one round, scan the remaining set for the **next umbrella** opportunity; iterate — don't stop after a few merges. When the library holds no more clusters worth folding, stage nothing and stop.

--- a/src/autoharness/hook/on_session_start.py
+++ b/src/autoharness/hook/on_session_start.py
@@ -74,6 +74,8 @@ def last_run_summary(roots):
         line += f" ({', '.join(last['families'])})"
     if last.get("absorbed"):
         line += f"; merged {last['absorbed']} into umbrellas"
+    if last.get("uncategorized"):
+        line += f"; {last['uncategorized']} landed with no category (grouped under general)"
     return line
 
 

--- a/src/autoharness/hook/promoter.py
+++ b/src/autoharness/hook/promoter.py
@@ -181,7 +181,19 @@ def promote(intent, *, roots=None, repo_name=None):
         _land(action, intent, body, level, name, root)
     except ValueError as exc:
         return _reject(action, level, [("landing", str(exc))])
-    return {"ok": True, "action": action, "level": level, "findings": []}
+    return {"ok": True, "action": action, "level": level, "findings": [], "notes": _notes(action, body)}
+
+
+def _notes(action, body):
+    """Fail-open observations on a landed intent: not a rejection, not silence either.
+
+    A missing category only groups the skill badly (the index falls back to `general`), so refusing
+    real content over it is out of proportion — the opposite call from the description gate, where a
+    cue-less description can never be recalled at all. It still has to reach the account, or the
+    library drifts into one flat group with nobody noticing."""
+    if action not in ("create", "update"):
+        return []
+    return [] if (validate._frontmatter(body) or {}).get("category") else ["category"]
 
 
 def sweep(roots=None):
@@ -197,7 +209,7 @@ def _account(run_id, intents, verdicts, proot):
     facts, so a rejected create would vanish without trace — this account is where verdicts live.
     last_run.json feeds the one-line SessionStart summary and is consumed after one injection."""
     rows = [{"action": v.get("action"), "name": i.get("name"), "ok": v["ok"],
-             "findings": [f[0] for f in v.get("findings", [])]}
+             "findings": [f[0] for f in v.get("findings", [])], "notes": v.get("notes", [])}
             for i, v in zip(intents, verdicts, strict=True)]
     landed = sum(1 for r in rows if r["ok"])
     absorbed = sum(1 for i, v in zip(intents, verdicts, strict=True)
@@ -211,7 +223,9 @@ def _account(run_id, intents, verdicts, proot):
     atomic.write_text(state / "last_run.json",
                       json.dumps({"run_id": run_id, "landed": landed,
                                   "rejected": len(rows) - landed, "absorbed": absorbed,
-                                  "families": families}, ensure_ascii=False))
+                                  "families": families,
+                                  "uncategorized": sum(1 for r in rows if "category" in r["notes"])},
+                                 ensure_ascii=False))
 
 
 def drain(run_id, *, roots=None, repo_name=None):

--- a/src/autoharness/lib/format_spec.md
+++ b/src/autoharness/lib/format_spec.md
@@ -12,13 +12,17 @@ YAML frontmatter that parses, carrying at least:
 - `description` — the trigger; see "Description is the trigger" below. This is what the host matches
   recall on, so a cue-less label never fires and is rejected.
 
-Optional, and worth setting:
-
 - `category` — one lowercase word or hyphenated phrase naming the class of work the skill serves
-  (`testing`, `git-workflow`, `deployment`). An open set: reuse a category already present in the
-  index rather than minting a near-synonym. It groups the injected recall index — omitted, the skill
-  lands in `general`, and a library where everything is `general` is a flat list again. A single safe
-  segment (letters, digits, `.`, `_`, `-`); anything else is rejected.
+  (`testing`, `git-workflow`, `deployment`). An open set: **pick one already visible in the injected
+  index**, and mint a new one only when nothing existing fits — the index is the candidate list, and
+  a library of near-synonym categories groups no better than none. It is what the session-start index
+  groups by, so a skill without one lands in `general`.
+
+  Enforcement is deliberately asymmetric with the description gate: an illegal value (anything but a
+  single safe segment of letters, digits, `.`, `_`, `-`) is **rejected**, but a *missing* one is
+  **allowed through** and noted in the run account — a cue-less description can never be recalled at
+  all, while a missing category only files the skill badly. The curator backfills what lands without
+  one.
 
 ## Description is the trigger — write it to this shape
 

--- a/tests/test_curator_agent.py
+++ b/tests/test_curator_agent.py
@@ -58,3 +58,12 @@ def test_curator_judges_by_maintainer_bar_not_pairwise():
 def test_curator_requires_absorbed_into_on_delete():
     body = AGENT.read_text()
     assert "absorbed_into" in body  # field is mandatory language for the curator (fail-closed downstream)
+
+
+def test_curator_carries_the_category_duties():
+    # the curator is the only organ that can move both levers: fold content into an umbrella, and
+    # re-file the label. Without these three it never writes a category and the index stays flat.
+    body = AGENT.read_text().lower()
+    assert "category" in body
+    assert "backfill" in body or "back-fill" in body  # (b) existing skills get a category over time
+    assert "same category is not a reason" in body   # (c) labelling must not substitute for merging

--- a/tests/test_on_session_start.py
+++ b/tests/test_on_session_start.py
@@ -1,3 +1,5 @@
+import json
+
 from autoharness import config
 from autoharness.hook import on_session_start
 from autoharness.lib import layer, sidecar, skill_store
@@ -178,3 +180,23 @@ def test_summary_shown_even_with_empty_library(tmp_path):
                                                       "families": ["safety"], "absorbed": 0}))
     out = on_session_start.on_session_start(roots=roots)
     assert out["context"] and "rejected 3" in out["context"]  # anti-silence beats empty-index None
+
+
+def test_summary_line_reports_uncategorized_landings(tmp_path):
+    # fail-open still has to be visible: a run that landed skills without a category says so
+    roots = {"global": tmp_path / "g", "project": tmp_path / "p"}
+    state = layer.state_dir("project", roots["project"])
+    state.mkdir(parents=True, exist_ok=True)
+    (state / "last_run.json").write_text(json.dumps(
+        {"run_id": "r1", "landed": 2, "rejected": 0, "absorbed": 0, "families": [], "uncategorized": 2}))
+    line = on_session_start.last_run_summary(roots)
+    assert "2" in line and "categor" in line.lower()
+
+
+def test_summary_line_silent_when_all_categorized(tmp_path):
+    roots = {"global": tmp_path / "g", "project": tmp_path / "p"}
+    state = layer.state_dir("project", roots["project"])
+    state.mkdir(parents=True, exist_ok=True)
+    (state / "last_run.json").write_text(json.dumps(
+        {"run_id": "r1", "landed": 2, "rejected": 0, "absorbed": 0, "families": [], "uncategorized": 0}))
+    assert "categor" not in on_session_start.last_run_summary(roots).lower()

--- a/tests/test_promoter.py
+++ b/tests/test_promoter.py
@@ -459,3 +459,44 @@ def test_drain_writes_run_account_and_last_run(tmp_path):
     assert [v["ok"] for v in run["verdicts"]] == [True, False]
     last = json.loads((state / "last_run.json").read_text())
     assert last["landed"] == 1 and last["rejected"] == 1
+
+
+CATEGORIZED_BODY = ("---\nname: foo\ndescription: Use when formatting a date as ISO.\n"
+                    "category: dates\n---\n# Foo\nUse strftime.\n")
+
+
+def test_missing_category_lands_but_is_noted(tmp_path):
+    # fail-open, unlike the description gate: a missing category only groups the skill badly,
+    # so rejecting real content over it is out of proportion — but it must not be silent
+    roots = _roots(tmp_path)
+    v = promoter.promote(_create(), roots=roots)
+    assert v["ok"] and "category" in v["notes"]
+    assert skill_store.exists("project", "foo", roots["project"])
+
+
+def test_present_category_is_not_noted(tmp_path):
+    roots = _roots(tmp_path)
+    v = promoter.promote(_create(body=CATEGORIZED_BODY), roots=roots)
+    assert v["ok"] and not v.get("notes")
+
+
+def test_illegal_category_still_rejected(tmp_path):
+    # format stays fail-closed: a path-shaped category would break index grouping and path safety
+    roots = _roots(tmp_path)
+    body = CATEGORIZED_BODY.replace("category: dates", "category: dates/iso")
+    v = promoter.promote(_create(body=body), roots=roots)
+    assert not v["ok"] and "category" in _families(v)
+    assert not skill_store.exists("project", "foo", roots["project"])
+
+
+def test_run_account_carries_uncategorized_count(tmp_path):
+    roots = _roots(tmp_path)
+    proot = roots["project"]
+    intent_queue.append("run-cat", _create(name="uncat"), proot)
+    intent_queue.append("run-cat", _create(name="cat", body=CATEGORIZED_BODY.replace("name: foo", "name: cat")),
+                        proot)
+    promoter.drain("run-cat", roots=roots)
+    last = json.loads((layer.state_dir("project", proot) / "last_run.json").read_text())
+    assert last["uncategorized"] == 1  # only the one that landed without a category
+    rows = json.loads((layer.state_dir("project", proot) / "runs" / "run-cat.json").read_text())["verdicts"]
+    assert {r["name"]: r.get("notes") for r in rows}["uncat"] == ["category"]

--- a/tests/test_reflector_agent.py
+++ b/tests/test_reflector_agent.py
@@ -77,3 +77,12 @@ def test_prompt_carries_reconcile_duty():
     # F1 (new-supersedes-old): a distilled new rule must hunt down contradicting old statements
     body = AGENT.read_text().lower()
     assert "supersede" in body or "contradict" in body
+
+
+def test_reflector_picks_category_from_the_injected_index():
+    # our defence against category inflation: hermes gets it free (categories are directories the
+    # model already sees); we have to say it, because the field is free text
+    body = AGENT.read_text().lower()
+    assert "category" in body and "index" in body
+    i = body.index("`category:`")
+    assert "index" in body[i - 400:i + 400]


### PR DESCRIPTION
Roadmap Phase 15 ([category-lifecycle](docs/plans/category-lifecycle.md) C1/C2).

`category` has been validated and used to group the session-start index since v0.4.0, but nothing ever *wrote* it. The design named the curator as a writer; the prompt never mentioned the field. Result: every skill lands in `general` and the grouping is decorative — the mechanism exists and is guaranteed idle, which is the same shape as the `calls≈0` failure.

## Changes

**curator** gets the three duties the design specified: an umbrella and everything it absorbs share a category; skills it keeps get their category backfilled (one `patch` each, only where it is confident — a wrong label is worse than `general`, which at least reads as "unfiled"); and `keep` now says explicitly that **sharing a category is not a reason not to merge**. That last one guards the failure this change could otherwise introduce: filing two narrow skills under one label is bookkeeping, not consolidation.

**promoter** treats a missing category as fail-open: the intent lands, the verdict carries a note, and the note surfaces in the run account and in the next session's summary line ("2 landed with no category"). This is deliberately the opposite call from the Phase 14 description gate — a cue-less description can never be recalled at all, so it is refused; a missing category only files the skill badly, so refusing real content over it is out of proportion. An *illegal* category value stays fail-closed, as before.

**Ordering note** recorded in the design: "curator prunes by looking inside a category first" has to wait until backfill has actually run, since a library that is entirely `general` gives that pruning nothing to work with.

394 tests (up from 386), ruff clean.