### PR TITLE
Phase 16: index injection budget with whole-category demotion

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ configure unless you want to change the pace.
 
 | Variable | Default | What it does |
 |---|---|---|
+| `AUTOHARNESS_INDEX_MAX_LINES` | `0` | Budget for the session-start index, counted in rendered lines. Over it, whole categories collapse to a single names-only line — least-used first, and never removed, because a name that leaves the index is a capability the model stops reaching for. `0` disables the budget, which is the shipping default until there is a measured recall baseline: the ranking reads use counts, and a low count today may only mean the skill was never offered. |
 | `AUTOHARNESS_INDEX_DESC_MAX_CHARS` | `60` | Per-line description budget in the session-start index. The index is a scan surface, not the full trigger text — raise it for longer lines, at the cost of context on every session. |
 | `AUTOHARNESS_SKILL_DESC_MAX_CHARS` | `1024` | Hard cap on a skill's own description, matching the host's documented limit; a longer one is rejected rather than silently truncated at load. |
 | `AUTOHARNESS_SKILL_BODY_MAX_LINES` | `25` | Altitude cap: a `SKILL.md` body over this many non-blank lines is rejected as a transcript rather than a rule. Backing detail belongs in the skill's `references/`. |

--- a/src/autoharness/config.py
+++ b/src/autoharness/config.py
@@ -43,6 +43,12 @@ SKILL_DESC_MAX_CHARS = _int_env("AUTOHARNESS_SKILL_DESC_MAX_CHARS", 1024)
 # self-injected recall index (SessionStart additionalContext): per-line description truncation,
 # mirroring Hermes's tier-0 index discipline — the index is a scan surface, not the full trigger text.
 INDEX_DESC_MAX_CHARS = _int_env("AUTOHARNESS_INDEX_DESC_MAX_CHARS", 60)
+# injection budget: rendered index lines (category headers + entries). Over it, whole categories
+# collapse to one names-only line, least-earned first — never removed (mng.md: a name that leaves the
+# index is a capability the model stops reaching for). 0 = no budget, the shipping default until the
+# recall baseline exists: the ranking eats use counts, and while surfacing itself is unverified a low
+# count may only mean "never offered".
+INDEX_MAX_LINES = _int_env("AUTOHARNESS_INDEX_MAX_LINES", 0)
 
 # folder-skill subfile caps (ponytail: placeholders like STAGE_MAX_BODY_BYTES, calibrate in experiments/)
 STAGE_MAX_FILES = 8

--- a/src/autoharness/hook/on_session_start.py
+++ b/src/autoharness/hook/on_session_start.py
@@ -23,10 +23,34 @@ INDEX_HEADER = (
     "Self-accumulated skills (autoharness-managed). When the task at hand matches a "
     "description below, you MUST consider loading that skill before proceeding."
 )
+DEMOTION_NOTE = (
+    "(Categories marked [names only] are outside this session's budget, so their descriptions are "
+    "omitted — the skills still load normally by name.)"
+)
 
 
 def _sanitize(text, limit):
     return " ".join(str(text).split())[:limit]  # line-based surface: newlines are forgery, collapse them
+
+
+def _demoted(groups, budget):
+    """Which categories collapse to a names-only line so the index fits its budget.
+
+    Ranked by use per entry — what a category earns for the lines it costs — ascending, so the
+    coldest give up their descriptions first. Demotion is the only lever: an entry is never dropped
+    (mng.md), so the floor is one line per category and a budget below that simply demotes all.
+    """
+    cost = sum(1 + len(v) for v in groups.values())
+    if not budget or cost <= budget:
+        return frozenset()
+    ranked = sorted(groups, key=lambda c: (sum(u for _, u in groups[c]) / len(groups[c]), c))
+    demoted = set()
+    for cat in ranked:
+        if cost <= budget:
+            break
+        demoted.add(cat)
+        cost -= len(groups[cat])  # the header line stays, its entries fold into it
+    return frozenset(demoted)
 
 
 def recall_index(roots):
@@ -43,13 +67,22 @@ def recall_index(roots):
             fm = validate._frontmatter(path.read_text()) or {}
             desc = _sanitize(fm.get("description") or "(no description)", config.INDEX_DESC_MAX_CHARS)
             cat = _sanitize(fm.get("category") or "general", 64) or "general"
-            groups.setdefault(cat, []).append(f"- {_sanitize(name, 64)} [{lyr}]: {desc}")
+            entry = f"- {_sanitize(name, 64)} [{lyr}]: {desc}"
+            groups.setdefault(cat, []).append((entry, sidecar.read(lyr, name, root).get("use", 0)))
     if not groups:
         return None  # empty library -> zero injection
+    demoted = _demoted(groups, config.INDEX_MAX_LINES)
     lines = [INDEX_HEADER, ""]
+    if demoted:
+        lines += [DEMOTION_NOTE, ""]
     for cat in sorted(groups):
+        entries = sorted(e for e, _ in groups[cat])
+        if cat in demoted:
+            names = ", ".join(e.split(" [", 1)[0][2:] for e in entries)
+            lines.append(f"## {cat} [names only]: {names}")
+            continue
         lines.append(f"## {cat}")
-        lines.extend(sorted(groups[cat]))
+        lines.extend(entries)
     return "\n".join(lines)
 
 

--- a/tests/test_on_session_start.py
+++ b/tests/test_on_session_start.py
@@ -200,3 +200,65 @@ def test_summary_line_silent_when_all_categorized(tmp_path):
     (state / "last_run.json").write_text(json.dumps(
         {"run_id": "r1", "landed": 2, "rejected": 0, "absorbed": 0, "families": [], "uncategorized": 0}))
     assert "categor" not in on_session_start.last_run_summary(roots).lower()
+
+
+def _seed_used(roots, name, category, use, lvl="project"):
+    _seed_desc(roots, name, f"use when {name}", lvl=lvl, category=category)
+    s = sidecar.read(lvl, name, roots[lvl])
+    s["use"] = use
+    sidecar.write(lvl, name, s, roots[lvl])
+
+
+def test_index_budget_off_by_default_leaves_output_untouched(tmp_path):
+    # the safety net: shipping the budget must not change a single injected line until it is turned on
+    roots = _roots(tmp_path)
+    for i in range(6):
+        _seed_used(roots, f"s{i}", "ops", use=0)
+    assert config.INDEX_MAX_LINES == 0  # 0 = no budget
+    ctx = on_session_start.recall_index(roots)
+    assert ctx.count("\n- ") == 6 and "names only" not in ctx
+
+
+def test_index_over_budget_demotes_the_least_used_category(tmp_path, monkeypatch):
+    roots = _roots(tmp_path)
+    _seed_used(roots, "hot-a", "hot", use=50)
+    _seed_used(roots, "hot-b", "hot", use=40)
+    _seed_used(roots, "cold-a", "cold", use=0)
+    _seed_used(roots, "cold-b", "cold", use=0)
+    monkeypatch.setattr(config, "INDEX_MAX_LINES", 5)  # 2 headers + 4 entries = 6 > 5
+    ctx = on_session_start.recall_index(roots)
+    assert "names only" in ctx
+    # the cold category lost its descriptions; the hot one kept them
+    assert "use when cold-a" not in ctx
+    assert "use when hot-a" in ctx
+
+
+def test_demotion_never_removes_a_skill_name(tmp_path, monkeypatch):
+    # hermes' own comment records this as an incident: pruning entries caused silent capability loss,
+    # because models do not go looking for what the index stopped showing them
+    roots = _roots(tmp_path)
+    for i in range(4):
+        _seed_used(roots, f"cold-{i}", "cold", use=0)
+    _seed_used(roots, "hot", "hot", use=99)
+    monkeypatch.setattr(config, "INDEX_MAX_LINES", 3)
+    ctx = on_session_start.recall_index(roots)
+    for i in range(4):
+        assert f"cold-{i}" in ctx  # names survive demotion, always
+    assert "hot" in ctx
+
+
+def test_demotion_ranks_general_like_any_other_category(tmp_path, monkeypatch):
+    # general is not privileged: a used general beats an unused named category
+    roots = _roots(tmp_path)
+    _seed_used(roots, "unfiled", None, use=30)
+    _seed_used(roots, "named-a", "named", use=0)
+    _seed_used(roots, "named-b", "named", use=0)
+    monkeypatch.setattr(config, "INDEX_MAX_LINES", 4)
+    ctx = on_session_start.recall_index(roots)
+    assert "use when unfiled" in ctx
+    assert "use when named-a" not in ctx
+
+
+def test_budget_does_not_resurrect_an_empty_library(tmp_path, monkeypatch):
+    monkeypatch.setattr(config, "INDEX_MAX_LINES", 1)
+    assert on_session_start.recall_index(_roots(tmp_path)) is None


### PR DESCRIPTION
Roadmap Phase 16 ([mng](docs/research-loom/design/mng.md) injection-budget section).

The session-start index truncated each line but never counted them: its size was bounded only by the capacity caps — 70 lines, 2-3k tokens on every single session — and grew with the library.

`INDEX_MAX_LINES` bounds the rendered index. Over budget, whole categories collapse to one `## <category> [names only]: a, b, c` line, ranked by **use per entry** (what a category earns for the lines it costs), coldest first.

**Entries are never dropped**, and that is not a preference — it is copied from hermes-agent's own incident note in `agent/coding_context.py`: an earlier revision pruned non-coding categories out of the index entirely and caused silent capability loss, because models do not reach for `skills_list` to rediscover what the index stopped showing them. Demotion drops descriptions; every name stays loadable.

**Ships inert.** Default is `0` (no budget), with a test asserting the output is byte-identical to today's while it is off. The ranking reads use counts, and until the E9 recall baseline exists a low count may only mean the skill was never offered — turning the budget on is gated on that measurement, the same way the graduation review is.

399 tests, ruff clean.