### PR TITLE
Phase 17: per-category recall metrics

### DIFF
--- a/src/autoharness/lib/metrics.py
+++ b/src/autoharness/lib/metrics.py
@@ -18,7 +18,7 @@ window is deferred with the same open question in mng.md.
 """
 import json
 
-from autoharness.lib import layer, ledger, sidecar, skill_store
+from autoharness.lib import layer, ledger, sidecar, skill_store, validate
 
 
 def _live_symbols(lyr, root):
@@ -69,6 +69,35 @@ def _funnel(lyr, root):
     return {"proposed": proposed, "landed": landed, "rejected": proposed - landed}, families
 
 
+def _category(lyr, name, root):
+    body = skill_store.read_body(lyr, name, root) or ""
+    return (validate._frontmatter(body) or {}).get("category") or "general"
+
+
+def _by_category(lyr, root, live, cards, requests):
+    """Per-category recall, on the layer's own denominator.
+
+    Answers the one question the library-level number cannot: which classes of work are actually
+    being pulled and which are dead weight — the only evidence that says whether to keep depositing
+    into a category. A category with no uses stays in the report at zero; dropping it would read as
+    "no such category" rather than "this one is dead".
+
+    Not the same statistic as the index's demotion ranking (mng.md), which divides by entries rather
+    than requests: that one asks what a category earns for the lines it costs, this one asks how
+    often it is reached for.
+    """
+    groups = {}
+    for name, card in zip(live, cards, strict=True):
+        g = groups.setdefault(_category(lyr, name, root), {"live_symbols": 0, "use_total": 0, "view_total": 0})
+        g["live_symbols"] += 1
+        g["use_total"] += card.get("use", 0)
+        g["view_total"] += card.get("view", 0)
+    for g in groups.values():
+        g["recall_rate"] = g["use_total"] / requests if requests else 0
+        g["view_rate"] = g["view_total"] / requests if requests else 0
+    return dict(sorted(groups.items()))
+
+
 def _layer_metrics(lyr, root):
     from autoharness.lib import counters
 
@@ -94,6 +123,7 @@ def _layer_metrics(lyr, root):
         "funnel": funnel,
         "reject_families": families,
         "reuse_after_patch": len(reused) / len(patched) if patched else 0,
+        "by_category": _by_category(lyr, root, live, cards, requests),
     }
 
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -85,3 +85,63 @@ def test_metrics_never_mutate_anything(tmp_path):
     before = sidecar.read("project", "a", roots["project"])
     metrics.collect(roots)
     assert sidecar.read("project", "a", roots["project"]) == before  # observation only
+
+
+def _seed_cat(roots, name, category, use=0, view=0, lvl="project"):
+    root = roots[lvl]
+    cat = f"category: {category}\n" if category else ""
+    skill_store.write_body(lvl, name, f"---\nname: {name}\ndescription: use when {name}\n{cat}---\nb", root)
+    s = sidecar.create(lvl, name, 0, root)
+    s.update(use=use, view=view)
+    sidecar.write(lvl, name, s, root)
+
+
+def test_category_rates_partition_the_layer_totals(tmp_path):
+    # the per-category split must add back up to the layer number, or one of the two is lying
+    roots = _roots(tmp_path)
+    _requests(roots, "project", 50)
+    _seed_cat(roots, "hot-a", "ops", use=10, view=2)
+    _seed_cat(roots, "hot-b", "ops", use=5, view=1)
+    _seed_cat(roots, "cold", "docs", use=0, view=3)
+    m = metrics.collect(roots)["project"]
+    by = m["by_category"]
+    assert sum(c["use_total"] for c in by.values()) == m["use_total"]
+    assert sum(c["view_total"] for c in by.values()) == m["view_total"]
+    assert sum(c["live_symbols"] for c in by.values()) == m["live_symbols"]
+
+
+def test_category_recall_rate_shares_the_layer_denominator(tmp_path):
+    roots = _roots(tmp_path)
+    _requests(roots, "project", 40)
+    _seed_cat(roots, "a", "ops", use=8)
+    _seed_cat(roots, "b", "docs", use=2)
+    by = metrics.collect(roots)["project"]["by_category"]
+    assert by["ops"]["recall_rate"] > by["docs"]["recall_rate"]  # same denominator, more uses
+    assert by["ops"]["recall_rate"] == 8 / 40
+
+
+def test_uncategorized_symbols_report_under_general(tmp_path):
+    roots = _roots(tmp_path)
+    _requests(roots, "project", 10)
+    _seed_cat(roots, "unfiled", None, use=1)
+    assert metrics.collect(roots)["project"]["by_category"]["general"]["use_total"] == 1
+
+
+def test_dead_category_is_visible_as_zero_not_absent(tmp_path):
+    # the point of the dimension: "which category is entirely dead" must be readable, and a dead
+    # category that vanished from the report would read as "no such category"
+    roots = _roots(tmp_path)
+    _requests(roots, "project", 20)
+    _seed_cat(roots, "alive", "ops", use=4)
+    _seed_cat(roots, "dead", "legacy", use=0, view=0)
+    by = metrics.collect(roots)["project"]["by_category"]
+    assert by["legacy"]["recall_rate"] == 0 and by["legacy"]["live_symbols"] == 1
+
+
+def test_category_dimension_does_not_reach_lifecycle(tmp_path):
+    # observation only: lifecycle.evaluate has no category input, so no metric can become a quota
+    import inspect
+
+    from autoharness.lib import lifecycle
+    assert "category" not in inspect.signature(lifecycle.evaluate).parameters
+    assert "category" not in inspect.getsource(lifecycle)


### PR DESCRIPTION
Roadmap Phase 17, closing the category batch ([metrics](docs/research-loom/design/metrics.md) category-dimension section).

The library-level recall rate cannot answer what the category field exists for: **which classes of work are actually pulled, and which are dead weight**. That is the only evidence that says whether to keep depositing into a category.

`by_category` splits use/view per category over the layer's own request denominator. Tests assert the split *partitions* the layer totals (uses, views and symbol counts add back up), so the two numbers cannot drift apart silently.

A category with zero uses **stays in the report at zero** rather than disappearing — absent reads as "no such category" instead of "this one is dead", and that confusion is precisely what let `calls≈0` go unnoticed for weeks.

**Correction to my own design note:** I had written that this shares a derivation with the Phase 16 demotion ranking. It does not, and the docs are fixed. The ranking divides by *entries* (what a category earns for the lines it costs); this divides by *requests* (how often it is reached for). Different denominators, different questions — merging them would have made one of the two wrong.

Observation only, with a regression test asserting `lifecycle` never takes a category: the moment a category feeds eviction, it becomes a quota the model can game by naming.

404 tests, ruff clean.