### PR TITLE
fix(reflector): forbid claiming a verdict it cannot observe

### DIFF
--- a/agents/reflector.md
+++ b/agents/reflector.md
@@ -60,7 +60,7 @@ To drop a subfile that is stale or wrong, stage a `remove_file` intent carrying 
 
 ## Emitting intents (call the `stage_skill` tool)
 
-**You act by calling the `stage_skill` tool — not by writing text.** Do not output the SKILL.md, the action, or the fields as prose in your reply; a textual description creates nothing. The *only* thing that records a change is an actual invocation of the `stage_skill` tool. Stage one intent per distinct lesson — several lessons, several calls. After they return, briefly confirm what you staged.
+**You act by calling the `stage_skill` tool — not by writing text.** Do not output the SKILL.md, the action, or the fields as prose in your reply; a textual description creates nothing. The *only* thing that records a change is an actual invocation of the `stage_skill` tool. Stage one intent per distinct lesson — several lessons, several calls. After they return, briefly confirm **what you staged, and nothing beyond that**: the promoter validates and writes only after this session has ended, so you **cannot know** whether an intent landed, was rejected, or why. Report the staging, never the outcome — a confident claim about a verdict you did not see is worse than silence, because it reads as evidence the pipeline worked.
 
 Tool arguments:
 

--- a/tests/test_reflector_agent.py
+++ b/tests/test_reflector_agent.py
@@ -86,3 +86,12 @@ def test_reflector_picks_category_from_the_injected_index():
     assert "category" in body and "index" in body
     i = body.index("`category:`")
     assert "index" in body[i - 400:i + 400]
+
+
+def test_reflector_may_not_claim_the_promoter_verdict():
+    # E11: with the promoter running after the child exits, one replay had the reflector report
+    # "both accepted by the promoter with no errors" while nothing had been written at all. It
+    # cannot observe the verdict, so the prompt must forbid asserting one.
+    body = AGENT.read_text().lower()
+    assert "cannot know" in body or "do not claim" in body
+    assert "promoter" in body


### PR DESCRIPTION
Found by E11's live replay. On one run the reflector reported *"Both accepted by the promoter with no errors"* while nothing had been written at all — the MCP server had not loaded, so it never had a `stage_skill` tool.

It cannot observe the verdict by construction: the promoter validates and writes after the child session has exited. Any claim about the outcome is invention, and a confident one is worse than silence — "the promoter accepted it" is exactly the line an operator reads as evidence that the pipeline worked, and stops looking.

The prompt now says to report what was staged and nothing beyond it, with the reason stated so the boundary is understood rather than memorised.