### PR TITLE
chore: bump to 0.5.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autoharness",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Per-symbol maintenance optimizer for an agent's skill layer — learns skills from real runs and keeps them by adherence in use, not by an offline eval score.",
   "author": {
     "name": "Tigerless Labs"


### PR DESCRIPTION
Ships PRs #98 and #99, both found by E11's live replay of real session history:

- the description budget (hermes' rule: the description *is* the index line) enforced at the tool boundary, where the author can still act on the error
- the reflector no longer claiming promoter verdicts it has no way to observe

Experiment record: `experiments/E11_lara_replay/results.md` (local; `experiments/` is not shipped).