### PR TITLE
feat(index): a switch to suspend self-injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ configure unless you want to change the pace.
 
 | Variable | Default | What it does |
 |---|---|---|
+| `AUTOHARNESS_INDEX_SUSPENDED` | `0` | Set to `1` to stop injecting the index entirely. Everything else keeps running — the lifecycle pass, the use/view counters, the last-run summary — so this is the switch for measuring what the index is actually worth, and for anyone unwilling to spend the context on it. |
 | `AUTOHARNESS_INDEX_MAX_LINES` | `0` | Budget for the session-start index, counted in rendered lines. Over it, whole categories collapse to a single names-only line — least-used first, and never removed, because a name that leaves the index is a capability the model stops reaching for. `0` disables the budget, which is the shipping default until there is a measured recall baseline: the ranking reads use counts, and a low count today may only mean the skill was never offered. |
 | `AUTOHARNESS_INDEX_DESC_MAX_CHARS` | `60` | Per-line description budget in the session-start index. The index is a scan surface, not the full trigger text — raise it for longer lines, at the cost of context on every session. |
 | `AUTOHARNESS_SKILL_DESC_MAX_CHARS` | `1024` | Hard cap on a skill's own description, matching the host's documented limit; a longer one is rejected rather than silently truncated at load. |

--- a/src/autoharness/config.py
+++ b/src/autoharness/config.py
@@ -49,6 +49,11 @@ INDEX_DESC_MAX_CHARS = _int_env("AUTOHARNESS_INDEX_DESC_MAX_CHARS", 60)
 # recall baseline exists: the ranking eats use counts, and while surfacing itself is unverified a low
 # count may only mean "never offered".
 INDEX_MAX_LINES = _int_env("AUTOHARNESS_INDEX_MAX_LINES", 0)
+# self-injection off switch: the index stops being emitted, everything else (lifecycle pass,
+# use/view counters, the last-run summary) is untouched. Needed because the only other way to run
+# without the index is to run without the plugin — which also removes the counters that measure the
+# result. Also a legitimate operator knob for anyone unwilling to spend the context every session.
+INDEX_SUSPENDED = bool(_int_env("AUTOHARNESS_INDEX_SUSPENDED", 0))
 
 # folder-skill subfile caps (ponytail: placeholders like STAGE_MAX_BODY_BYTES, calibrate in experiments/)
 STAGE_MAX_FILES = 8

--- a/src/autoharness/hook/on_session_start.py
+++ b/src/autoharness/hook/on_session_start.py
@@ -64,6 +64,8 @@ def _demoted(groups, budget):
 
 
 def recall_index(roots):
+    if config.INDEX_SUSPENDED:
+        return None
     groups = {}
     for lyr in layer.LAYERS:
         root = roots.get(lyr)

--- a/tests/test_on_session_start.py
+++ b/tests/test_on_session_start.py
@@ -281,3 +281,28 @@ def test_index_leaves_a_fitting_description_alone(tmp_path):
     _seed_desc(roots, "modern", "Use when auditing a repo.")
     ctx = on_session_start.recall_index(roots)
     assert "Use when auditing a repo." in ctx and "..." not in ctx
+
+
+def test_index_suspended_injects_nothing_but_keeps_counting(tmp_path, monkeypatch):
+    # the A/B arm E9 needs: the recall index off while every other part of the pipeline — the
+    # lifecycle pass, the use/view counters, the last-run summary — behaves identically. Without it
+    # the only way to get a no-index arm is to run without the plugin, which also removes the
+    # instrument measuring the result.
+    roots = _roots(tmp_path)
+    _seed_desc(roots, "a-skill", "use when a", category="ops")
+    monkeypatch.setattr(config, "INDEX_SUSPENDED", True)
+    assert on_session_start.recall_index(roots) is None
+    out = on_session_start.on_session_start(roots=roots)
+    assert out["context"] is None
+    assert "project" in out["archived"]  # lifecycle still ran
+
+
+def test_index_suspended_still_lets_the_summary_through(tmp_path, monkeypatch):
+    # suspending the index must not suppress the anti-silence line: they are separate obligations
+    roots = _roots(tmp_path)
+    state = layer.state_dir("project", roots["project"])
+    state.mkdir(parents=True, exist_ok=True)
+    (state / "last_run.json").write_text(json.dumps(
+        {"run_id": "r1", "landed": 1, "rejected": 0, "absorbed": 0, "families": []}))
+    monkeypatch.setattr(config, "INDEX_SUSPENDED", True)
+    assert "landed 1" in on_session_start.on_session_start(roots=roots)["context"]


### PR DESCRIPTION
Needed by [E9](docs/plans/e9-recall.md): the baseline arm must have the index off and **everything else identical** — lifecycle pass, use/view counters, last-run summary all still running. Without this switch the only no-index configuration is "no plugin", which also removes the instrument that measures the outcome; the two arms would then differ in more than the treatment.

Independently a legitimate knob: the index spends context on every session, and until now there was no way to decline it while keeping the lifecycle management.

Two tests: suspended injects nothing while the lifecycle still runs, and the anti-silence summary line still gets through (they are separate obligations).