### PR TITLE
remove(index): drop the line budget, never enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,6 @@ configure unless you want to change the pace.
 | Variable | Default | What it does |
 |---|---|---|
 | `AUTOHARNESS_INDEX_SUSPENDED` | `0` | Set to `1` to stop injecting the index entirely. Everything else keeps running — the lifecycle pass, the use/view counters, the last-run summary — so this is the switch for measuring what the index is actually worth, and for anyone unwilling to spend the context on it. |
-| `AUTOHARNESS_INDEX_MAX_LINES` | `0` | Budget for the session-start index, counted in rendered lines. Over it, whole categories collapse to a single names-only line — least-used first, and never removed, because a name that leaves the index is a capability the model stops reaching for. `0` disables the budget, which is the shipping default until there is a measured recall baseline: the ranking reads use counts, and a low count today may only mean the skill was never offered. |
 | `AUTOHARNESS_INDEX_DESC_MAX_CHARS` | `60` | Per-line description budget in the session-start index. The index is a scan surface, not the full trigger text — raise it for longer lines, at the cost of context on every session. |
 | `AUTOHARNESS_SKILL_DESC_MAX_CHARS` | `1024` | Hard cap on a skill's own description, matching the host's documented limit; a longer one is rejected rather than silently truncated at load. |
 | `AUTOHARNESS_SKILL_BODY_MAX_LINES` | `25` | Altitude cap: a `SKILL.md` body over this many non-blank lines is rejected as a transcript rather than a rule. Backing detail belongs in the skill's `references/`. |
@@ -107,7 +106,7 @@ configure unless you want to change the pace.
 |---|---|---|
 | `AUTOHARNESS_MATURITY_PROJECT` | `100` | Probation gate, project layer: after this many requests have arrived in its layer since a skill landed, it faces graduation review. Until then it's recalled as usual but can't be archived. |
 | `AUTOHARNESS_MATURITY_GLOBAL` | `300` | Same gate for the global layer — higher because a global skill loads in every project. |
-| `AUTOHARNESS_CAPACITY_PROJECT` | `50` | Cap on *mature* skills in the project layer. For graduates, capacity contention is the only death: nothing is archived until the mature pool exceeds this, then the lowest usage rates go first. |
+| `AUTOHARNESS_CAPACITY_PROJECT` | `50` | Cap on *mature* skills in the project layer. It is also what bounds the session-start index: one line per live skill, so the index can never exceed the two caps combined. For graduates, capacity contention is the only death: nothing is archived until the mature pool exceeds this, then the lowest usage rates go first. |
 | `AUTOHARNESS_CAPACITY_GLOBAL` | `20` | Same cap for the global layer — smaller because its blast radius is every project. |
 | `AUTOHARNESS_GRADUATION_SUSPENDED` | `0` | Set to `1` to park graduation review entirely, so nothing is archived for going unused. Meant for when you have reason to doubt the recall surface: archiving on zero use would then be punishing skills for never having been offered. Capacity contention still applies. |
 | `AUTOHARNESS_SNAPSHOT_KEEP` | `5` | How many pre-run snapshots of each skill tree the curator keeps before merging. A merge is the one operation a single atomic rename can't undo. |

--- a/src/autoharness/config.py
+++ b/src/autoharness/config.py
@@ -43,12 +43,6 @@ SKILL_DESC_MAX_CHARS = _int_env("AUTOHARNESS_SKILL_DESC_MAX_CHARS", 1024)
 # self-injected recall index (SessionStart additionalContext): per-line description truncation,
 # mirroring Hermes's tier-0 index discipline — the index is a scan surface, not the full trigger text.
 INDEX_DESC_MAX_CHARS = _int_env("AUTOHARNESS_INDEX_DESC_MAX_CHARS", 60)
-# injection budget: rendered index lines (category headers + entries). Over it, whole categories
-# collapse to one names-only line, least-earned first — never removed (mng.md: a name that leaves the
-# index is a capability the model stops reaching for). 0 = no budget, the shipping default until the
-# recall baseline exists: the ranking eats use counts, and while surfacing itself is unverified a low
-# count may only mean "never offered".
-INDEX_MAX_LINES = _int_env("AUTOHARNESS_INDEX_MAX_LINES", 0)
 # self-injection off switch: the index stops being emitted, everything else (lifecycle pass,
 # use/view counters, the last-run summary) is untouched. Needed because the only other way to run
 # without the index is to run without the plugin — which also removes the counters that measure the

--- a/src/autoharness/hook/on_session_start.py
+++ b/src/autoharness/hook/on_session_start.py
@@ -23,10 +23,6 @@ INDEX_HEADER = (
     "Self-accumulated skills (autoharness-managed). When the task at hand matches a "
     "description below, you MUST consider loading that skill before proceeding."
 )
-DEMOTION_NOTE = (
-    "(Categories marked [names only] are outside this session's budget, so their descriptions are "
-    "omitted — the skills still load normally by name.)"
-)
 
 
 def _sanitize(text, limit):
@@ -41,26 +37,6 @@ def _fit(text, limit):
     than take a fragment for the whole trigger."""
     flat = " ".join(str(text).split())
     return flat if len(flat) <= limit else flat[:limit - 3] + "..."
-
-
-def _demoted(groups, budget):
-    """Which categories collapse to a names-only line so the index fits its budget.
-
-    Ranked by use per entry — what a category earns for the lines it costs — ascending, so the
-    coldest give up their descriptions first. Demotion is the only lever: an entry is never dropped
-    (mng.md), so the floor is one line per category and a budget below that simply demotes all.
-    """
-    cost = sum(1 + len(v) for v in groups.values())
-    if not budget or cost <= budget:
-        return frozenset()
-    ranked = sorted(groups, key=lambda c: (sum(u for _, u in groups[c]) / len(groups[c]), c))
-    demoted = set()
-    for cat in ranked:
-        if cost <= budget:
-            break
-        demoted.add(cat)
-        cost -= len(groups[cat])  # the header line stays, its entries fold into it
-    return frozenset(demoted)
 
 
 def recall_index(roots):
@@ -79,22 +55,13 @@ def recall_index(roots):
             fm = validate._frontmatter(path.read_text()) or {}
             desc = _fit(fm.get("description") or "(no description)", config.INDEX_DESC_MAX_CHARS)
             cat = _sanitize(fm.get("category") or "general", 64) or "general"
-            entry = f"- {_sanitize(name, 64)} [{lyr}]: {desc}"
-            groups.setdefault(cat, []).append((entry, sidecar.read(lyr, name, root).get("use", 0)))
+            groups.setdefault(cat, []).append(f"- {_sanitize(name, 64)} [{lyr}]: {desc}")
     if not groups:
         return None  # empty library -> zero injection
-    demoted = _demoted(groups, config.INDEX_MAX_LINES)
     lines = [INDEX_HEADER, ""]
-    if demoted:
-        lines += [DEMOTION_NOTE, ""]
     for cat in sorted(groups):
-        entries = sorted(e for e, _ in groups[cat])
-        if cat in demoted:
-            names = ", ".join(e.split(" [", 1)[0][2:] for e in entries)
-            lines.append(f"## {cat} [names only]: {names}")
-            continue
         lines.append(f"## {cat}")
-        lines.extend(entries)
+        lines.extend(sorted(groups[cat]))
     return "\n".join(lines)
 
 

--- a/tests/test_on_session_start.py
+++ b/tests/test_on_session_start.py
@@ -202,66 +202,10 @@ def test_summary_line_silent_when_all_categorized(tmp_path):
     assert "categor" not in on_session_start.last_run_summary(roots).lower()
 
 
-def _seed_used(roots, name, category, use, lvl="project"):
-    _seed_desc(roots, name, f"use when {name}", lvl=lvl, category=category)
-    s = sidecar.read(lvl, name, roots[lvl])
-    s["use"] = use
-    sidecar.write(lvl, name, s, roots[lvl])
 
 
-def test_index_budget_off_by_default_leaves_output_untouched(tmp_path):
-    # the safety net: shipping the budget must not change a single injected line until it is turned on
-    roots = _roots(tmp_path)
-    for i in range(6):
-        _seed_used(roots, f"s{i}", "ops", use=0)
-    assert config.INDEX_MAX_LINES == 0  # 0 = no budget
-    ctx = on_session_start.recall_index(roots)
-    assert ctx.count("\n- ") == 6 and "names only" not in ctx
 
 
-def test_index_over_budget_demotes_the_least_used_category(tmp_path, monkeypatch):
-    roots = _roots(tmp_path)
-    _seed_used(roots, "hot-a", "hot", use=50)
-    _seed_used(roots, "hot-b", "hot", use=40)
-    _seed_used(roots, "cold-a", "cold", use=0)
-    _seed_used(roots, "cold-b", "cold", use=0)
-    monkeypatch.setattr(config, "INDEX_MAX_LINES", 5)  # 2 headers + 4 entries = 6 > 5
-    ctx = on_session_start.recall_index(roots)
-    assert "names only" in ctx
-    # the cold category lost its descriptions; the hot one kept them
-    assert "use when cold-a" not in ctx
-    assert "use when hot-a" in ctx
-
-
-def test_demotion_never_removes_a_skill_name(tmp_path, monkeypatch):
-    # hermes' own comment records this as an incident: pruning entries caused silent capability loss,
-    # because models do not go looking for what the index stopped showing them
-    roots = _roots(tmp_path)
-    for i in range(4):
-        _seed_used(roots, f"cold-{i}", "cold", use=0)
-    _seed_used(roots, "hot", "hot", use=99)
-    monkeypatch.setattr(config, "INDEX_MAX_LINES", 3)
-    ctx = on_session_start.recall_index(roots)
-    for i in range(4):
-        assert f"cold-{i}" in ctx  # names survive demotion, always
-    assert "hot" in ctx
-
-
-def test_demotion_ranks_general_like_any_other_category(tmp_path, monkeypatch):
-    # general is not privileged: a used general beats an unused named category
-    roots = _roots(tmp_path)
-    _seed_used(roots, "unfiled", None, use=30)
-    _seed_used(roots, "named-a", "named", use=0)
-    _seed_used(roots, "named-b", "named", use=0)
-    monkeypatch.setattr(config, "INDEX_MAX_LINES", 4)
-    ctx = on_session_start.recall_index(roots)
-    assert "use when unfiled" in ctx
-    assert "use when named-a" not in ctx
-
-
-def test_budget_does_not_resurrect_an_empty_library(tmp_path, monkeypatch):
-    monkeypatch.setattr(config, "INDEX_MAX_LINES", 1)
-    assert on_session_start.recall_index(_roots(tmp_path)) is None
 
 
 def test_index_marks_a_truncated_description_as_cut(tmp_path):


### PR DESCRIPTION
`INDEX_MAX_LINES` shipped inert (default `0`) in #95 and could not have been enabled safely: demotion ranked categories by use-per-entry, and in a young library every use is zero, so ordering fell through to the alphabetical tiebreak — `css` demoted before `devops` because of the letter c. A budget that fires on the alphabet is not a budget.

The index is already bounded: one line per live self-produced skill, and the two `CAPACITY` caps hold that at 70 lines (~3k tokens worst case). Hermes has no line budget either — its controls are the 60-char line and posture-based demotion.

Removed: the knob, `_demoted`, the names-only rendering, 5 tests (410 → 405). README's `CAPACITY_PROJECT` row now states that it also bounds the index. E9's gate list drops from three items to two.

If a library ever passes ~40 lines with a trustworthy use signal, redesign against that signal. The one rule worth keeping is recorded in the design doc: any future budget may demote descriptions, never remove a self-produced skill from the index.