### PR TITLE
chore: bump to 0.5.2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autoharness",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Per-symbol maintenance optimizer for an agent's skill layer — learns skills from real runs and keeps them by adherence in use, not by an offline eval score.",
   "author": {
     "name": "Tigerless Labs"


### PR DESCRIPTION
Ships #102 (`AUTOHARNESS_INDEX_SUSPENDED`: turn self-injection off while every counter keeps running — the A/B switch E9 needed, and a legitimate operator knob) and #103 (`AUTOHARNESS_INDEX_MAX_LINES` removed — shipped inert, could not be enabled safely, and the two `CAPACITY` caps already bound the index at 70 lines).

Default behaviour is unchanged. Anyone who had set `INDEX_MAX_LINES` saw no effect before and sees none now.