### PR TITLE
fix(learn): interactive sessions can stage, and Stop drains what they staged

### DIFF
--- a/src/autoharness/config.py
+++ b/src/autoharness/config.py
@@ -79,4 +79,9 @@ REFLECTOR_AGENT = "autoharness:reflector"  # the --agent reference for spawn (pl
 CURATOR_AGENT = "autoharness:curator"      # the --agent reference for the periodic consolidation pass (same spawn chain as reflector)
 CLAUDE_BIN = "claude"                       # the child-session executable for spawn; PATH resolution, overridable in tests
 RUN_ID_ENV = "AUTOHARNESS_RUN_ID"           # spawn injects the intent-queue run_id into the child session via env (read by stage_skill)
+# The queue for intents staged from a live user session (/learn, or the model acting on its own).
+# spawn injects a run id into every child it launches and drains that run when the child exits; a
+# user's own session has neither, so before this existed stage_skill refused with "unsafe run id"
+# and the shipped learn skill could never land anything. The main session's Stop drains this queue.
+INTERACTIVE_RUN_ID = "interactive"
 PROJECT_ROOT_ENV = "AUTOHARNESS_PROJECT_ROOT"  # same: repo root (where the queue is persisted)

--- a/src/autoharness/hook/dispatch.py
+++ b/src/autoharness/hook/dispatch.py
@@ -22,7 +22,13 @@ import subprocess
 import sys
 
 from autoharness import config
-from autoharness.hook import on_session_end, on_session_start, on_skill_call, on_stop
+from autoharness.hook import (
+    on_session_end,
+    on_session_start,
+    on_skill_call,
+    on_stop,
+    promoter,
+)
 from autoharness.lib import counters, layer
 
 _SANITIZE = re.compile(r"[^A-Za-z0-9_-]")
@@ -88,6 +94,7 @@ def dispatch(event, *, roots=None, reflect=None, consolidate=None):
                 return {"handled": name, "result": {"triggered": False, "reason": "recursion_guard"}}
             counters.bump_request(layer.GLOBAL, roots.get(layer.GLOBAL))  # MNG denominator (per turn)
             pcount = counters.bump_request(layer.PROJECT, proot)
+            promoter.drain(config.INTERACTIVE_RUN_ID, roots=roots)  # /learn and other in-session proposals; no-op when empty
             result = on_stop.on_stop(event, root=proot)
             if result.get("triggered"):
                 fire(event, result, roots)

--- a/src/autoharness/stage_skill/server.py
+++ b/src/autoharness/stage_skill/server.py
@@ -204,7 +204,7 @@ def handle(request, *, run_id, root=None):
 def serve(stdin=None, stdout=None):
     stdin = stdin or sys.stdin
     stdout = stdout or sys.stdout
-    run_id = os.environ.get(config.RUN_ID_ENV, "")
+    run_id = os.environ.get(config.RUN_ID_ENV) or config.INTERACTIVE_RUN_ID
     root = os.environ.get(config.PROJECT_ROOT_ENV) or None
     for line in stdin:
         line = line.strip()

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -257,3 +257,44 @@ def test_child_session_write_denied(tmp_path, monkeypatch):
     v = dispatch.dispatch({"hook_event_name": "PreToolUse", "tool_name": "Write",
                            "session_id": "s7"}, roots=_roots(tmp_path))
     assert v.get("deny")
+
+
+def _interactive_intent(name="learned"):
+    return {"action": "create", "name": name, "level": "project", "reason": "r", "evidence": "e",
+            "body": f"---\nname: {name}\ndescription: Use when a learned thing applies.\n---\nRule.\n"}
+
+
+def test_main_session_stop_drains_the_interactive_queue(tmp_path, monkeypatch):
+    # nothing else drains it: spawn drains only its own run ids after a child exits. Without this a
+    # /learn proposal sits in the queue forever and the skill's own promise ("lands; reported next
+    # session start") is false.
+    from autoharness.lib import intent_queue, skill_store
+    roots = {"global": tmp_path / "g", "project": tmp_path / "p"}
+    monkeypatch.delenv(config.CHILD_SESSION_ENV, raising=False)
+    intent_queue.append(config.INTERACTIVE_RUN_ID, _interactive_intent(), roots["project"])
+    dispatch.dispatch({"hook_event_name": "Stop", "session_id": "s1"}, roots=roots, reflect=lambda *a: None)
+    assert skill_store.exists("project", "learned", roots["project"])
+    assert not list(intent_queue.read(config.INTERACTIVE_RUN_ID, roots["project"]))
+
+
+def test_child_session_stop_leaves_the_interactive_queue_alone(tmp_path, monkeypatch):
+    # a child has its own run id and spawn drains it; touching the user's queue from there would be
+    # a reflector landing user proposals under the reflector's identity
+    from autoharness.lib import intent_queue
+    roots = {"global": tmp_path / "g", "project": tmp_path / "p"}
+    monkeypatch.setenv(config.CHILD_SESSION_ENV, "1")
+    intent_queue.append(config.INTERACTIVE_RUN_ID, _interactive_intent(), roots["project"])
+    dispatch.dispatch({"hook_event_name": "Stop", "session_id": "s1"}, roots=roots, reflect=lambda *a: None)
+    assert len(list(intent_queue.read(config.INTERACTIVE_RUN_ID, roots["project"]))) == 1
+
+
+def test_stop_with_empty_interactive_queue_writes_no_run_account(tmp_path, monkeypatch):
+    # every turn drains; an empty drain must not leave a runs/ file or a last_run summary behind,
+    # or the next session start would report a run that never happened
+    from autoharness.lib import layer
+    roots = {"global": tmp_path / "g", "project": tmp_path / "p"}
+    monkeypatch.delenv(config.CHILD_SESSION_ENV, raising=False)
+    dispatch.dispatch({"hook_event_name": "Stop", "session_id": "s1"}, roots=roots, reflect=lambda *a: None)
+    state = layer.state_dir("project", roots["project"])
+    assert not (state / "last_run.json").exists()
+    assert not list((state / "runs").glob("*.json")) if (state / "runs").exists() else True

--- a/tests/test_stage_skill.py
+++ b/tests/test_stage_skill.py
@@ -384,3 +384,19 @@ def test_stage_accepts_a_description_inside_the_budget(tmp_path):
     out = server.stage({"action": "create", "name": "foo", "level": "project", "body": body,
                         "reason": "r", "evidence": "e"}, run_id="rb2", root=tmp_path)
     assert out["ok"] and len(list(intent_queue.read("rb2", tmp_path))) == 1
+
+
+def test_serve_without_run_id_env_uses_the_interactive_queue(tmp_path, monkeypatch):
+    # A live user session (/learn, or the model on its own) has no spawn-injected run id. The first
+    # real report from such a session was "unsafe run id" — the tool refused, and the learn skill had
+    # never been able to land anything. Absence of the env must mean "the interactive queue", not "no".
+    import io
+    monkeypatch.delenv(config.RUN_ID_ENV, raising=False)
+    monkeypatch.setenv(config.PROJECT_ROOT_ENV, str(tmp_path))
+    req = {"jsonrpc": "2.0", "id": 1, "method": "tools/call",
+           "params": {"name": "stage_skill", "arguments": _params()}}
+    out = io.StringIO()
+    server.serve(stdin=io.StringIO(json.dumps(req) + "\n"), stdout=out)
+    reply = json.loads(out.getvalue().strip().splitlines()[-1])
+    assert "unsafe" not in json.dumps(reply)
+    assert len(list(intent_queue.read(config.INTERACTIVE_RUN_ID, tmp_path))) == 1


### PR DESCRIPTION
Reported from a live user session: `stage_skill` refused with **"unsafe run id"**, and the session fell back to writing a plain skill directory by hand.

## Two gaps, not one

1. **No run id outside a spawned child.** `stage_skill` read its run id only from the env var `spawn` injects into child sessions. A user's own session — `/learn`, or the model deciding to stage — had none, so the tool refused.
2. **Nothing would have drained it anyway.** `promoter.drain` ran only at the tail of `spawn.run` / `run_curator`. An interactive intent would have sat in the queue forever.

Consequence: **the shipped `/learn` skill has never landed anything**, while its own text promised *"the deterministic promoter validates and lands; rejects are reported at the next session start."* The design doc's line "零新代码路径" for the learn entry was the assumption that hid this.

## Fix

- Absence of the env var means the configured **interactive queue** (`INTERACTIVE_RUN_ID`), not refusal.
- The main session's **`Stop` handler drains that queue every turn** — no-op when empty (test asserts no phantom run account), and child sessions leave it alone (they have their own run id; `spawn` drains it).
- Landed/rejected surface through the existing next-session summary line, so the learn skill's promise is now true.

Design docs (`ref.md`, `stage-skill.md`) updated first with the interactive-session contract. 409 tests (+4), ruff clean.