### PR TITLE
chore: bump to 0.5.3

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autoharness",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Per-symbol maintenance optimizer for an agent's skill layer — learns skills from real runs and keeps them by adherence in use, not by an offline eval score.",
   "author": {
     "name": "Tigerless Labs"


### PR DESCRIPTION
Ships #105: `/learn` (and any in-session `stage_skill` call) now actually lands — the tool accepts a session without a spawn-injected run id, and the main session's `Stop` drains the interactive queue. Before this the shipped learn skill had never landed anything.