### PR TITLE
docs: move the video link to Acknowledgements, flagged third-party

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@
   <img src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Ftigerless-labs%2Fautoharness%2Fmain%2F.claude-plugin%2Fplugin.json&query=%24.version&label=release&prefix=v&color=brightgreen" alt="release" /> <img src="https://img.shields.io/badge/python-3.11%2B-blue.svg" alt="python" /> <img src="https://img.shields.io/badge/platform-Linux%20%7C%20macOS-lightgrey.svg" alt="platform" /> <img src="https://img.shields.io/badge/license-MIT-yellow.svg" alt="license MIT" />
 </p>
 
-<p align="center"><a href="https://www.youtube.com/watch?v=TM6tGpug1Hc">▶ Watch: AI Coding Tools — the Tigerless Labs workflow</a></p>
-
 **autoharness is a self-learning skill layer for Claude Code.** It **learns** skills from your real
 sessions, **merges** same-scenario ones instead of stacking near-duplicates, **updates** them in use,
 and **prunes** any that stop getting used — so the layer **stays clean on its own**, **touching only
@@ -242,6 +240,9 @@ benchmark exists.
 [NousResearch/hermes-agent](https://github.com/NousResearch/hermes-agent) — studying its
 auto-skill-creation and memory-consolidation design helped sharpen autoharness's adherence-based,
 daemon-free take.
+
+[AI Coding Tools (Tigerless Labs Workflow 2026)](https://www.youtube.com/watch?v=TM6tGpug1Hc) —
+a third-party walkthrough by the AI Insider channel; not ours, and not reviewed by us.
 
 Built by Tigerless Labs.
 


### PR DESCRIPTION
Follow-up to #107: the video is not ours, so it belongs at the bottom with attribution rather than under the title.

🤖 Generated with [Claude Code](https://claude.com/claude-code)