### PR TITLE
fix: normalize _rules lru_cache key when rules_path is None

### DIFF
--- a/src/autoharness/lib/redact.py
+++ b/src/autoharness/lib/redact.py
@@ -25,6 +25,7 @@ def _rules(rules_path):
 
 def redact(text, rules_path=None):
     out = text
-    for category, name, rx in _rules(rules_path):
+    key = str(rules_path) if rules_path else str(config.REDACTION_RULES)
+    for category, name, rx in _rules(key):
         out = rx.sub(f"[REDACTED:{category}:{name}]", out)
     return out

--- a/tests/test_redact_cache_key.py
+++ b/tests/test_redact_cache_key.py
@@ -1,0 +1,13 @@
+"""Verify _rules lru_cache key is normalized so None and the default path share one entry."""
+from autoharness import config
+from autoharness.lib import redact
+
+def test_cache_key_normalized():
+    redact._rules.cache_clear()
+    redact.redact("hello")
+    after_none = redact._rules.cache_info()
+    redact.redact("hello", rules_path=str(config.REDACTION_RULES))
+    after_explicit = redact._rules.cache_info()
+    assert after_explicit.hits == after_none.hits + 1, (
+        f"expected cache hit on second call, got misses={after_explicit.misses} hits={after_explicit.hits}"
+    )


### PR DESCRIPTION
## Problem

`_rules()` is cached via `@lru_cache` keyed on its `rules_path` argument. When `redact()` is called with `rules_path=None` (the default), the cache key is `None`. A later call passing the explicit default path (`rules_path=str(config.REDACTION_RULES)`) uses a different key, causing the same file to be parsed and compiled again unnecessarily.

## Solution

Normalize the cache key in `redact()` before calling `_rules()`: when `rules_path` is `None`, resolve it to `str(config.REDACTION_RULES)` so both calling patterns share a single cache entry.

## Testing

Added `tests/test_redact_cache_key.py` which asserts that a second call with the explicit default path produces a cache hit rather than a miss.
