### PR TITLE
fix: warn on invalid env var overrides and restrict boolean coercion to 0/1

### DIFF
--- a/src/autoharness/config.py
+++ b/src/autoharness/config.py
@@ -12,9 +12,13 @@ from autoharness.lib import layer
 
 
 def _int_env(name, default):
+    import warnings
     try:
         return int(os.environ[name])
-    except (KeyError, ValueError):
+    except KeyError:
+        return default
+    except ValueError:
+        warnings.warn(f"{name}={os.environ[name]!r} is not a valid integer; using default {default}", stacklevel=2)
         return default
 
 
@@ -47,7 +51,15 @@ INDEX_DESC_MAX_CHARS = _int_env("AUTOHARNESS_INDEX_DESC_MAX_CHARS", 60)
 # use/view counters, the last-run summary) is untouched. Needed because the only other way to run
 # without the index is to run without the plugin — which also removes the counters that measure the
 # result. Also a legitimate operator knob for anyone unwilling to spend the context every session.
-INDEX_SUSPENDED = bool(_int_env("AUTOHARNESS_INDEX_SUSPENDED", 0))
+def _bool_env(name, default):
+    val = _int_env(name, int(default))
+    if val not in (0, 1):
+        import warnings
+        warnings.warn(f"{name}={val} should be 0 or 1; treating non-zero as True", stacklevel=2)
+    return bool(val)
+
+
+INDEX_SUSPENDED = _bool_env("AUTOHARNESS_INDEX_SUSPENDED", False)
 
 # folder-skill subfile caps (ponytail: placeholders like STAGE_MAX_BODY_BYTES, calibrate in experiments/)
 STAGE_MAX_FILES = 8
@@ -61,7 +73,7 @@ CAPACITY = {layer.GLOBAL: _int_env("AUTOHARNESS_CAPACITY_GLOBAL", 20),
             layer.PROJECT: _int_env("AUTOHARNESS_CAPACITY_PROJECT", 50)}
 # graduation-review suspend gate (direction C): while the recall surface is known-broken, archiving
 # for zero use buries surfacing's failure — flip on to park the review, capacity contention unaffected.
-GRADUATION_REVIEW_SUSPENDED = bool(_int_env("AUTOHARNESS_GRADUATION_SUSPENDED", 0))
+GRADUATION_REVIEW_SUSPENDED = _bool_env("AUTOHARNESS_GRADUATION_SUSPENDED", False)
 SNAPSHOT_KEEP = _int_env("AUTOHARNESS_SNAPSHOT_KEEP", 5)  # curator pre-run library snapshots per layer (mirrors Hermes)
 
 _LIB = Path(__file__).parent / "lib"

--- a/tests/test_config_env_validation.py
+++ b/tests/test_config_env_validation.py
@@ -1,0 +1,43 @@
+"""Verify _int_env warns on invalid values and _bool_env restricts to 0/1."""
+import os
+import warnings
+from unittest.mock import patch
+
+def test_int_env_warns_on_invalid():
+    # Reload to pick up patched env
+    from autoharness import config as cfg
+    with patch.dict(os.environ, {"AUTOHARNESS_TEST_INT": "abc"}):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = cfg._int_env("AUTOHARNESS_TEST_INT", 42)
+            assert result == 42
+            assert len(w) == 1
+            assert "not a valid integer" in str(w[0].message)
+
+def test_int_env_silent_on_missing():
+    from autoharness import config as cfg
+    with patch.dict(os.environ, {}, clear=True):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = cfg._int_env("AUTOHARNESS_NONEXISTENT_XYZ", 99)
+            assert result == 99
+            assert len(w) == 0
+
+def test_bool_env_warns_on_non_binary():
+    from autoharness import config as cfg
+    with patch.dict(os.environ, {"AUTOHARNESS_TEST_BOOL": "2"}):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = cfg._bool_env("AUTOHARNESS_TEST_BOOL", False)
+            assert result is True
+            assert len(w) == 1
+            assert "should be 0 or 1" in str(w[0].message)
+
+def test_bool_env_accepts_0_and_1():
+    from autoharness import config as cfg
+    with patch.dict(os.environ, {"AUTOHARNESS_TEST_B1": "1", "AUTOHARNESS_TEST_B0": "0"}):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            assert cfg._bool_env("AUTOHARNESS_TEST_B1", False) is True
+            assert cfg._bool_env("AUTOHARNESS_TEST_B0", True) is False
+            assert len(w) == 0


### PR DESCRIPTION
Two small config issues rolled into one fix:

- `_int_env` used to silently swallow `ValueError` (e.g. `AUTOHARNESS_REFLECT_EVERY_N=abc` fell back to 50 with no feedback). Now it emits a `warnings.warn` on invalid values while still returning the default.
- `INDEX_SUSPENDED` and `GRADUATION_REVIEW_SUSPENDED` were `bool(_int_env(...))`, which meant any non-zero integer (including `-1` or `2`) silently became `True`. New `_bool_env` helper only accepts `0`/`1` and warns on anything else.

Added `tests/test_config_env_validation.py` covering all four cases (valid int, missing key, invalid int, non-binary bool).
