### PR TITLE
fix(stage_skill): carry absorbed_into field into delete intent dict

### DIFF
--- a/src/autoharness/stage_skill/server.py
+++ b/src/autoharness/stage_skill/server.py
@@ -151,6 +151,8 @@ def _intent(params):
         intent["new_string"] = params["new_string"]
     elif action == "remove_file":
         intent["path"] = params["path"]
+    if action == "delete" and params.get("absorbed_into"):
+        intent["absorbed_into"] = params["absorbed_into"]
     return intent
 
 


### PR DESCRIPTION
## Summary

The `_intent()` function in `stage_skill/server.py` accepts `absorbed_into` for delete actions but never carries it into the serialized intent dict. This causes three downstream failures:

1. The per-symbol ledger cannot distinguish a fold from a plain retirement
2. The umbrella existence guard becomes dead code (hallucination defense bypassed)
3. Session-start summaries always report zero absorptions

## Fix

Add the missing field assignment before returning the intent dict:

```python
if action == "delete" and params.get("absorbed_into"):
    intent["absorbed_into"] = params["absorbed_into"]
```

This is a 2-line surgical fix that wires up the validated parameter to the intent queue.

## Testing

- Verified `python3 -m py_compile` passes
- Diff is minimal and focused on the single missing field
