### PR TITLE
fix: preserve existing archive on name collision in skill_store

### DIFF
--- a/src/autoharness/lib/skill_store.py
+++ b/src/autoharness/lib/skill_store.py
@@ -9,6 +9,7 @@ LED/sidecar); landing a delete and MNG (Phase 6) eviction share this one path.
 """
 import os
 import shutil
+import time
 
 from autoharness.lib import atomic, layer
 
@@ -62,7 +63,8 @@ def archive(lyr, name, root=None):
     dest = layer.archive_dir(lyr, root) / name
     dest.parent.mkdir(parents=True, exist_ok=True)
     if dest.exists():
-        shutil.rmtree(dest)
+        ts = time.strftime("%Y%m%dT%H%M%S")
+        dest = dest.parent / f"{name}.{ts}"
     os.replace(sdir, dest)
     return dest
 
@@ -74,7 +76,8 @@ def restore(lyr, name, root=None):
     dest = layer.symbol_dir(lyr, name, root)
     dest.parent.mkdir(parents=True, exist_ok=True)
     if dest.exists():
-        shutil.rmtree(dest)
+        ts = time.strftime("%Y%m%dT%H%M%S")
+        dest = dest.parent / f"{name}.{ts}"
     os.replace(src, dest)
     return dest
 

--- a/tests/test_archive_collision.py
+++ b/tests/test_archive_collision.py
@@ -1,0 +1,57 @@
+"""Regression: archive/restore must not destroy existing data on name collision."""
+import os
+import tempfile
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+from autoharness.lib import skill_store
+
+
+def _make_tree(root, lyr, name, marker="live"):
+    """Create a fake skill dir with a marker file."""
+    skills = Path(root) / lyr / "skills" / name
+    skills.mkdir(parents=True, exist_ok=True)
+    (skills / "SKILL.md").write_text(f"# {name}\nmarker={marker}")
+    return skills
+
+
+def test_archive_collision_preserves_old(tmp_path):
+    """Archiving a skill when an archive of the same name exists must not destroy the old archive."""
+    root = str(tmp_path)
+    # Simulate: skill exists in archive AND in live
+    _make_tree(root, "global", "foo", marker="archived")
+    archive_dest = Path(root) / "global" / ".archive" / "foo"
+    archive_dest.mkdir(parents=True, exist_ok=True)
+    (archive_dest / "SKILL.md").write_text("# foo\nmarker=old-archive")
+
+    # Patch layer helpers to use our tmp layout
+    with patch("autoharness.lib.skill_store.layer") as lyr_mod:
+        lyr_mod.symbol_dir.return_value = Path(root) / "global" / "skills" / "foo"
+        lyr_mod.archive_dir.return_value = Path(root) / "global" / ".archive"
+        result = skill_store.archive("global", "foo", root)
+
+    # The old archive must still exist
+    assert (archive_dest / "SKILL.md").read_text() == "# foo\nmarker=old-archive"
+    # The new archive landed at a timestamped path
+    assert result is not None
+    assert result != archive_dest or (archive_dest / "SKILL.md").read_text().startswith("# foo")
+
+
+def test_restore_collision_preserves_live(tmp_path):
+    """Restoring a skill when a live copy exists must not destroy the live copy."""
+    root = str(tmp_path)
+    _make_tree(root, "global", "foo", marker="live-current")
+    archive_src = Path(root) / "global" / ".archive" / "foo"
+    archive_src.mkdir(parents=True, exist_ok=True)
+    (archive_src / "SKILL.md").write_text("# foo\nmarker=from-archive")
+
+    with patch("autoharness.lib.skill_store.layer") as lyr_mod:
+        lyr_mod.symbol_dir.return_value = Path(root) / "global" / "skills" / "foo"
+        lyr_mod.archive_dir.return_value = Path(root) / "global" / ".archive"
+        result = skill_store.restore("global", "foo", root)
+
+    # The original live copy must still exist
+    live = Path(root) / "global" / "skills" / "foo"
+    assert (live / "SKILL.md").read_text() == "# foo\nmarker=live-current"
+    assert result is not None


### PR DESCRIPTION
## Problem

`skill_store.archive()` silently destroys an existing archive when a skill with the same name is archived again. The `shutil.rmtree(dest)` call permanently deletes the old archive (including its ledger, sidecar, and evidence) before moving the new one in. The same destructive pattern exists in `restore()`.

This causes silent data loss when a skill goes through create → archive → restore → archive cycles, or when two skills with the same name exist across layers.

## Fix

Instead of `shutil.rmtree(dest)`, append a timestamp suffix (`name.YYYYMMDDTHHMMSS`) when a collision is detected. The old archive is preserved at its original path and the new one lands alongside it. Applied to both `archive()` and `restore()`.

## Changes

- `src/autoharness/lib/skill_store.py`: replace `shutil.rmtree` with timestamped rename on collision in both `archive()` and `restore()`
- `tests/test_archive_collision.py`: regression tests confirming old data is preserved

## Testing

```
python3 -m pytest tests/test_archive_collision.py -x -q
2 passed
```
