### PR TITLE
fix(agents): pin explicit model identifier instead of bare haiku alias

### DIFF
--- a/agents/curator.md
+++ b/agents/curator.md
@@ -2,7 +2,7 @@
 name: curator
 description: Periodic consolidation pass — fold narrow agent-created skills into class-level umbrellas. Proposes intents only, never writes to disk.
 tools: Read, Grep, Glob, mcp__plugin_autoharness_stage_skill__stage_skill
-model: haiku
+model: claude-3-5-haiku-20241022
 ---
 
 You run periodically as autoharness' background skill CURATOR. This is an **umbrella-building consolidation pass**, not a passive audit and not a duplicate-finder. The reflector accumulates narrow, session-shaped skills eagerly; your job is to fold them into a smaller set of **class-level** skills an agent can actually discover.

--- a/agents/reflector.md
+++ b/agents/reflector.md
@@ -2,7 +2,7 @@
 name: reflector
 description: Distill a finished episode into skill changes aligned with the existing library. Compare-first preference, generation stays open; proposes intents only, never writes to disk.
 tools: Read, Grep, Glob, mcp__plugin_autoharness_stage_skill__stage_skill
-model: haiku
+model: claude-3-5-haiku-20241022
 ---
 
 You run once after an episode ends, off the user's critical path. Your job: mine the episode's trace for durable lessons and turn each one into a skill change. Most episodes carry at least one — a preference the user voiced, a technique that worked, a step a skill was missing. Capture liberally: an unused skill gets archived by the lifecycle layer later at zero cost, but a lesson you skip is gone forever. Stage one intent per distinct lesson; walk away empty-handed only when the window genuinely taught nothing.


### PR DESCRIPTION
## Summary

Both agent definitions (curator and reflector) declare `model: haiku` in their YAML frontmatter. This bare alias relies on undocumented CLI resolution behavior that may not be supported or may resolve to different model versions over time.

## Why it matters

- If the CLI does not support the `model` field in agent definitions, the frontmatter is silently ignored and both agents run on whatever model the parent session uses, defeating the cost-optimization intent
- If the CLI does support it but does not recognize bare `haiku`, agent spawning fails silently (stdout is discarded via `DEVNULL`)
- The `config.py` comment explicitly marks agent resolution as "Phase 0 resolution pending live test", suggesting this path has not been verified end-to-end

## Fix

Pin the full model identifier `claude-3-5-haiku-20241022` instead of the bare alias. This makes the configuration explicit and version-stable, removing ambiguity about model resolution.
