### PR TITLE
fix: preserve unmatched quotes in frontmatter parser

### DIFF
--- a/src/autoharness/lib/validate.py
+++ b/src/autoharness/lib/validate.py
@@ -51,7 +51,10 @@ def _frontmatter(body):
         if not s or s.startswith("#") or ":" not in line:
             continue
         key, value = line.split(":", 1)
-        fm[key.strip()] = value.strip().strip('"').strip("'")
+        v = value.strip()
+        if len(v) >= 2 and v[0] == v[-1] and v[0] in ('"', "'"):
+            v = v[1:-1]
+        fm[key.strip()] = v
     return fm
 
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -284,3 +284,15 @@ def test_category_rejects_path_and_unsafe_segments():
         v = validate.validate({"action": "create", "level": "project", "name": "x",
                                "reason": "r", "evidence": "e"}, _body_with_category(bad))
         assert [f for f in v["findings"] if f[0] == "category"], bad
+
+def test_frontmatter_mixed_quotes():
+    # Single quote wrapping double quote should not be stripped
+    body = "---\nname: foo\ndescription: 'he said \"hello\"'\n---\n# Foo\n"
+    from autoharness.lib.validate import _frontmatter
+    fm = _frontmatter(body)
+    assert fm["description"] == 'he said "hello"'
+    
+    # Unmatched quotes should not be stripped
+    body2 = "---\nname: bar\ndescription: \"unmatched'\n---\n# Bar\n"
+    fm2 = _frontmatter(body2)
+    assert fm2["description"] == "\"unmatched'"


### PR DESCRIPTION
## Problem

`_frontmatter()` in `validate.py` strips both `"` and `'` sequentially from values, which produces incorrect results when a value has mismatched or nested quote types. For example, `"unmatched'` would be silently stripped to `unmatched`, losing data.

## Solution

Only strip a quote character when the value starts and ends with the same quote type. This preserves unmatched quotes as-is, which is the correct YAML-like behavior.

## Testing

Added `test_frontmatter_mixed_quotes` covering both a properly-wrapped value with inner quotes and the unmatched-quote edge case.
