### PR TITLE
fix: normalize cwd path before caching worktree root lookup

### DIFF
--- a/src/autoharness/lib/layer.py
+++ b/src/autoharness/lib/layer.py
@@ -33,8 +33,12 @@ def _check_name(name):
         raise ValueError(f"unsafe symbol name: {name!r}")
 
 
-@cache
 def _main_worktree_root(cwd):
+    return _main_worktree_root_resolved(str(Path(cwd).resolve()))
+
+
+@cache
+def _main_worktree_root_resolved(cwd):
     try:
         proc = subprocess.run(
             ["git", "rev-parse", "--git-dir", "--git-common-dir"],


### PR DESCRIPTION
Hey! I noticed that `_main_worktree_root` uses `@cache` with the raw `cwd` string as the key. This means calling it with `"."` vs `"/full/path/to/here"` would miss the cache and run git twice for the same directory. In a long-lived process like the MCP server, if the host changes directory between calls, the cache could also return a stale result for the same string key from a different actual directory.

**The fix:** resolve the path to its canonical form before passing it to the cached function. Split into a thin public wrapper (`_main_worktree_root`) that normalizes via `Path(cwd).resolve()`, and a `@cache`-decorated internal function (`_main_worktree_root_resolved`) that does the actual git lookup. Same behavior, but equivalent paths now hit the same cache entry.
