### PR TITLE
fix(learn): widen skill description trigger cues for better auto-recall

### DIFF
--- a/skills/learn/SKILL.md
+++ b/skills/learn/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: learn
-description: Use when the user says /learn or asks to save this lesson.
+description: "/learn: save, remember, or distill this lesson/skill"
 category: general
 ---
 # Learn: distill this session into the skill library


### PR DESCRIPTION
## Summary

The `/learn` skill description has narrow trigger cues — only the slash command and the phrase "save this lesson". Users expressing the same intent with different words ("remember that," "distill what we figured out," "add this as a skill") would not match, reducing auto-recall.

## Changes

Updated the description from:
```
Use when the user says /learn or asks to save this lesson.
```
to:
```
/learn: save, remember, or distill this lesson/skill
```

This adds trigger words `remember`, `distill`, and `skill` while staying under the 60-character `INDEX_DESC_MAX_CHARS` limit (52 characters). The quotes are required for YAML safety since the description contains a colon-space sequence.

## Impact

Broadens auto-recall for the primary on-demand entry point to the learning pipeline without exceeding the character budget.
