### PR TITLE
fix: guard detached launch against OSError and avoid run-id collisions

### DIFF
--- a/src/autoharness/hook/dispatch.py
+++ b/src/autoharness/hook/dispatch.py
@@ -15,6 +15,7 @@ platform contract pins the details:
 
 ponytail: detached launch is a fire-and-forget Popen; robustness of orphan / timeout isolation left for observation.
 """
+import hashlib
 import json
 import os
 import re
@@ -40,12 +41,18 @@ def _roots(roots):
 
 
 def _run_id(result):
-    sid = _SANITIZE.sub("", str(result.get("session_id") or "")) or "run"
+    raw = str(result.get("session_id") or "")
+    sid = _SANITIZE.sub("", raw)
+    if not sid:
+        sid = hashlib.sha256(raw.encode()).hexdigest()[:8] if raw else "run"
     return f"{sid}-{result.get('count', 0)}"
 
 
 def _curate_run_id(event, pcount):
-    sid = _SANITIZE.sub("", str(event.get("session_id") or "")) or "run"
+    raw = str(event.get("session_id") or "")
+    sid = _SANITIZE.sub("", raw)
+    if not sid:
+        sid = hashlib.sha256(raw.encode()).hexdigest()[:8] if raw else "run"
     return f"{sid}-c{pcount}"  # keyed on the monotonic request count → unique per curator launch
 
 
@@ -55,13 +62,17 @@ def _is_reflector(event):
 
 
 def _detached_launch(transcript_path, session_id, run_id, roots):
-    subprocess.Popen(  # host-detach: fire-and-forget so the Stop hook returns immediately
-        [sys.executable, "-m", "autoharness.hook.spawn",
-         str(transcript_path), str(session_id), run_id,
-         str(roots[layer.PROJECT]), str(roots[layer.GLOBAL])],
-        start_new_session=True, stdin=subprocess.DEVNULL,
-        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
-    )
+    try:
+        subprocess.Popen(  # host-detach: fire-and-forget so the Stop hook returns immediately
+            [sys.executable, "-m", "autoharness.hook.spawn",
+             str(transcript_path), str(session_id), run_id,
+             str(roots[layer.PROJECT]), str(roots[layer.GLOBAL])],
+            start_new_session=True, stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        )
+    except OSError as exc:
+        return {"error": f"detached_launch failed: {type(exc).__name__}: {exc}"}
+    return None
 
 
 def _reflect(event, result, roots, launch=None):

--- a/tests/test_dispatch_fixes.py
+++ b/tests/test_dispatch_fixes.py
@@ -1,0 +1,46 @@
+"""Regression tests for dispatch: _detached_launch error handling + _run_id collision avoidance."""
+from unittest.mock import patch
+
+from autoharness.hook import dispatch
+
+
+def test_run_id_empty_session_gets_hash():
+    """A session_id that sanitizes to empty should produce a unique hash, not bare 'run'."""
+    result = {"session_id": "...", "count": 5}
+    rid = dispatch._run_id(result)
+    assert rid != "run-5"
+    assert rid.endswith("-5")
+    # Two different session_ids that both sanitize to empty should differ
+    r1 = dispatch._run_id({"session_id": "...", "count": 0})
+    r2 = dispatch._run_id({"session_id": "???", "count": 0})
+    assert r1 != r2
+
+
+def test_run_id_normal_session_unchanged():
+    """A normal session_id should still produce the expected format."""
+    result = {"session_id": "abc-123", "count": 3}
+    assert dispatch._run_id(result) == "abc-123-3"
+
+
+def test_curate_run_id_empty_session_gets_hash():
+    """Same hash fallback for _curate_run_id."""
+    r1 = dispatch._curate_run_id({"session_id": "..."}, 10)
+    r2 = dispatch._curate_run_id({"session_id": "???"}, 10)
+    assert r1 != r2
+    assert r1.endswith("-c10")
+
+
+def test_detached_launch_oserror_returns_error():
+    """If Popen raises OSError, _detached_launch returns an error dict instead of propagating."""
+    with patch("autoharness.hook.dispatch.subprocess.Popen", side_effect=OSError("no interpreter")):
+        result = dispatch._detached_launch("/tmp/t", "sid", "run-0", {"project": "/p", "global": "/g"})
+    assert result is not None
+    assert "error" in result
+    assert "no interpreter" in result["error"]
+
+
+def test_detached_launch_success_returns_none():
+    """Normal Popen succeeds; _detached_launch returns None."""
+    with patch("autoharness.hook.dispatch.subprocess.Popen"):
+        result = dispatch._detached_launch("/tmp/t", "sid", "run-0", {"project": "/p", "global": "/g"})
+    assert result is None


### PR DESCRIPTION
## Problem

Two independent issues in `dispatch.py`:

1. **`_detached_launch` ignores subprocess errors.** If `Popen` raises `OSError` (e.g., interpreter not found, permission denied), the exception propagates to the generic catch in `dispatch()` and the reflection trigger is silently lost. The operator sees no indication that spawning failed.

2. **`_run_id` / `_curate_run_id` collision.** When a `session_id` sanitizes to an empty string, both functions fall back to the bare string `"run"`. Different sessions that all sanitize to empty share the same run-id prefix, causing intent queue collisions in the same JSONL file.

## Fix

1. Wrap `Popen` in `_detached_launch` with a `try/except OSError` block that returns an error dict, surfacing spawn failures to the caller instead of crashing the hook.

2. When the sanitized session_id is empty but the raw value is non-empty, derive a unique 8-char hex prefix from `hashlib.sha256(raw)` instead of falling back to `"run"`. Both `_run_id` and `_curate_run_id` are fixed symmetrically.

## Changes

- `src/autoharness/hook/dispatch.py`: `hashlib` import, hash fallback in `_run_id` + `_curate_run_id`, `OSError` guard in `_detached_launch`
- `tests/test_dispatch_fixes.py`: regression tests for both fixes

## Testing

```
python3 -m pytest tests/test_dispatch_fixes.py -x -q
5 passed
```
