### PR TITLE
fix: limit sweep_orphans to top-level skills directory

### DIFF
--- a/src/autoharness/lib/skill_store.py
+++ b/src/autoharness/lib/skill_store.py
@@ -84,7 +84,7 @@ def sweep_orphans(lyr, root=None):
     if not skills.exists():
         return []
     removed = []
-    for tmp in skills.rglob("*.tmp"):
+    for tmp in skills.glob("*.tmp"):  # top-level only; atomic.write_bytes writes here
         tmp.unlink()
         removed.append(tmp)
     return removed


### PR DESCRIPTION
- `sweep_orphans` used `rglob("*.tmp")`, recursing into every skill subdirectory (including `scripts/`, `assets/`)
- `atomic.write_bytes` only creates `.tmp` files at the skills directory top level, so the recursion was unnecessary
- a skill whose build script legitimately writes an `output.tmp` inside its own directory would have it silently deleted mid-execution by the sweep
- changed to `glob("*.tmp")` to only sweep the directory where `atomic.write_bytes` actually writes
