### PR TITLE
fix(check_doc_links): handle markdown links with URL query strings

### DIFF
--- a/tools/check_doc_links.py
+++ b/tools/check_doc_links.py
@@ -2,7 +2,7 @@ import re
 import sys
 from pathlib import Path
 
-_MD_LINK = re.compile(r"\]\(\s*([^)\s]+?\.md)(?:#[^)]*)?\s*\)")
+_MD_LINK = re.compile(r"\]\(\s*([^)\s?#]+?\.md)(?:[?#][^)]*)?\s*\)")
 _EXTERNAL = re.compile(r"^[a-z][a-z0-9+.-]*://")
 
 
@@ -31,6 +31,8 @@ def selftest():
     assert list(local_md_targets("see [x](a/b.md) and [ext](https://h.md)")) == ["a/b.md"]
     assert list(local_md_targets("anchor [y](../c/d.md#sec) ok")) == ["../c/d.md"]
     assert list(local_md_targets("plain `path.md` backtick, [[wiki]] prose")) == []
+    assert list(local_md_targets("query [z](file.md?v=2) ok")) == ["file.md"]
+    assert list(local_md_targets("both [w](file.md?v=2#sec) ok")) == ["file.md"]
     with tempfile.TemporaryDirectory() as tmp:
         root = Path(tmp)
         (root / ".archive").mkdir()


### PR DESCRIPTION
## Summary

The `_MD_LINK` regex in `check_doc_links.py` silently skips markdown links that carry URL query strings (e.g., `[text](file.md?raw=true)`). These links are neither verified nor reported as dangling — they fall through the scan entirely.

## Root cause

The capture group `([^)\s]+?\.md)` followed by optional `(?:#[^)]*)?` handles fragment anchors but not query strings. When a `?` appears after `.md`, the regex backtracks and fails to close, dropping the link silently.

## Fix

Change the capture group to exclude `?` and `#` from the path portion (`[^)\s?#]` instead of `[^)\s]`), and broaden the optional suffix to match either `?` or `#` as the first character: `(?:[?#][^)]*)?`. This handles:

- `file.md` (plain)
- `file.md#section` (fragment only)
- `file.md?v=2` (query only)
- `file.md?v=2#section` (query then fragment)

Added two selftest assertions covering query-only and query+fragment cases. Selftest passes.
