### PR TITLE
fix: restrict _is_reflector to namespace-qualified match

### DIFF
--- a/src/autoharness/hook/dispatch.py
+++ b/src/autoharness/hook/dispatch.py
@@ -51,7 +51,7 @@ def _curate_run_id(event, pcount):
 
 def _is_reflector(event):
     at = str(event.get("agent_type") or "")
-    return at == config.REFLECTOR_AGENT or at.endswith("reflector")
+    return at == config.REFLECTOR_AGENT or at.endswith(":reflector")
 
 
 def _detached_launch(transcript_path, session_id, run_id, roots):

--- a/tests/test_dispatch_reflector.py
+++ b/tests/test_dispatch_reflector.py
@@ -1,0 +1,20 @@
+"""Verify _is_reflector uses namespace-qualified match."""
+from autoharness.hook.dispatch import _is_reflector
+
+def test_canonical_reflector():
+    assert _is_reflector({"agent_type": "autoharness:reflector"})
+
+def test_other_namespace_reflector():
+    assert _is_reflector({"agent_type": "myplugin:reflector"})
+
+def test_hyphen_reflector_not_matched():
+    assert not _is_reflector({"agent_type": "custom-reflector"})
+
+def test_no_prefix_reflector_not_matched():
+    assert not _is_reflector({"agent_type": "reflector"})
+
+def test_unrelated_agent_not_matched():
+    assert not _is_reflector({"agent_type": "my-agent"})
+
+def test_empty_agent_type():
+    assert not _is_reflector({})


### PR DESCRIPTION
Hi! First-time contributor here.

The `_is_reflector` fallback in `dispatch.py` uses `at.endswith("reflector")`, which is broader than intended. Any agent type ending in `reflector` gets the reflector write-deny exemption -- including `custom-reflector`, `not-a-reflector`, or even bare `reflector` with no namespace prefix. This can cause unintended cross-plugin interference when third-party plugins register agents with similar names.

This PR changes the fallback to `at.endswith(":reflector")`, requiring the colon namespace separator. This still matches `autoharness:reflector` and any other properly-namespaced reflector (`myplugin:reflector`), while rejecting `custom-reflector`, bare `reflector`, and unrelated agents.

Tests cover all six cases: canonical reflector, other namespace, hyphenated, bare, unrelated agent, and empty agent type.