### PR TITLE
fix: atomic claim in last_run_summary to prevent concurrent duplicate reads

### DIFF
--- a/src/autoharness/hook/on_session_start.py
+++ b/src/autoharness/hook/on_session_start.py
@@ -71,13 +71,19 @@ def last_run_summary(roots):
     p = layer.state_dir(layer.PROJECT, roots.get(layer.PROJECT)) / "last_run.json"
     if not p.exists():
         return None
+    # Atomic rename to claim the file; concurrent callers get OSError and return None
+    consumed = p.with_suffix(".json.consuming")
     try:
-        last = json.loads(p.read_text())
+        p.rename(consumed)
+    except OSError:
+        return None
+    try:
+        last = json.loads(consumed.read_text())
     except (ValueError, OSError):
         return None
     finally:
         try:
-            p.unlink()
+            consumed.unlink()
         except OSError:
             pass
     line = (f"autoharness last run: landed {last.get('landed', 0)}, "


### PR DESCRIPTION
## Background

`last_run_summary()` is designed as a one-shot consumer: read the file once, then delete it. The current implementation reads first, then unconditionally unlinks in a `finally` block. If two session-start hooks run concurrently (overlapping sessions), both can read the file before either deletes it -- producing duplicate summaries. Alternatively, the second session finds the file already gone and gets no summary at all.

## Changes

Replace the read-then-unlink pattern with an atomic rename-to-claim: the first caller renames `last_run.json` to `last_run.json.consuming` (atomic on POSIX), then reads from the renamed path. A concurrent caller gets `OSError` from the rename and returns `None` immediately. This guarantees exactly-once consumption.
