### PR TITLE
fix: narrow _PLACEHOLDER regex to avoid false positives on markdown callout tags

### DIFF
--- a/src/autoharness/lib/validate.py
+++ b/src/autoharness/lib/validate.py
@@ -26,7 +26,7 @@ from autoharness import config
 from autoharness.lib import layer, skills_guard
 
 _FRONTMATTER = re.compile(r"\A---\n(.*?)\n---\n?", re.DOTALL)
-_PLACEHOLDER = re.compile(r"\b(TODO|FIXME|XXX):|<[A-Z][A-Z_]{2,}>")
+_PLACEHOLDER = re.compile(r"\b(TODO|FIXME|XXX):|<(?:TODO|FIXME|XXX|TBD|PLACEHOLDER|REPLACE[_ ]?ME|INSERT[_ ]?HERE|FILL[_ ]?IN)>")
 _ABS_PATH = re.compile(r"(?:/home/|/Users/|/root/)[^\s`)\]]+|[A-Za-z]:\\[^\s`)\]]+")
 _PY_REF = re.compile(r"[\w./-]+\.py")
 _SUBFILE_REF = re.compile(r"\b(?:{})/[A-Za-z0-9._/-]+".format("|".join(layer.SUBFILE_DIRS)))

--- a/tests/test_placeholder_regex.py
+++ b/tests/test_placeholder_regex.py
@@ -1,0 +1,21 @@
+"""Regression: _PLACEHOLDER must not match legitimate markdown callout tags."""
+from autoharness.lib.validate import _PLACEHOLDER
+
+
+def test_placeholder_still_catches_real_placeholders():
+    """Known placeholder tags are still detected."""
+    for tag in ["<TODO>", "<FIXME>", "<PLACEHOLDER>", "<TBD>", "<REPLACE_ME>", "<INSERT_HERE>"]:
+        assert _PLACEHOLDER.search(f"fill in {tag} later"), f"should match {tag}"
+
+
+def test_placeholder_ignores_markdown_callouts():
+    """Legitimate markdown callout tags must not trigger the completeness check."""
+    for tag in ["<NOTE>", "<IMPORTANT>", "<WARNING>", "<EXAMPLE>", "<CAUTION>", "<TIP>"]:
+        assert not _PLACEHOLDER.search(f"see {tag} for details"), f"should NOT match {tag}"
+
+
+def test_placeholder_still_catches_todo_fixme_colon():
+    """The TODO:/FIXME:/XXX: prefix form still works."""
+    assert _PLACEHOLDER.search("TODO: implement this")
+    assert _PLACEHOLDER.search("FIXME: broken")
+    assert _PLACEHOLDER.search("XXX: needs review")


### PR DESCRIPTION
## Problem

The `_PLACEHOLDER` regex in `validate.py` uses `<[A-Z][A-Z_]{2,}>` which matches any uppercase HTML-style tag. This triggers false positives on legitimate markdown callouts like `<NOTE>`, `<IMPORTANT>`, `<WARNING>`, `<EXAMPLE>`, etc. The completeness check then rejects the entire skill intent as containing a placeholder, and the reflector may strip valid formatting tags.

## Fix

Replace the generic `<[A-Z][A-Z_]{2,}>` alternation with an explicit allowlist of known placeholder tag names: `<TODO>`, `<FIXME>`, `<XXX>`, `<TBD>`, `<PLACEHOLDER>`, `<REPLACE_ME>`, `<INSERT_HERE>`, `<FILL_IN>`. The `TODO:`/`FIXME:`/`XXX:` colon-prefix form is unchanged.

## Changes

- `src/autoharness/lib/validate.py`: narrow `_PLACEHOLDER` regex tag alternation
- `tests/test_placeholder_regex.py`: regression tests confirming real placeholders still match and markdown callouts do not

## Testing

```
python3 -m pytest tests/test_placeholder_regex.py -x -q
3 passed
```
