### PR TITLE
fix: use deterministic hash for capacity contention tie-breaking

### DIFF
--- a/src/autoharness/lib/lifecycle.py
+++ b/src/autoharness/lib/lifecycle.py
@@ -13,6 +13,8 @@ skill_store.archive on each.
 ponytail: a rolling-window rate is deferred (open in mng.md).
 """
 
+import hashlib
+
 
 def _rate(use, denom):
     return use / denom if denom else 0.0
@@ -36,6 +38,6 @@ def evaluate(members, request_count, *, maturity, capacity, review_suspended=Fal
             continue  # spared zero-use symbols stay out of the pool either way
         survivors.append((_rate(use, denom), m["name"]))
     if len(survivors) > capacity:
-        survivors.sort(key=lambda rn: rn)  # ascending rate, ties broken stably by name
+        survivors.sort(key=lambda rn: (rn[0], hashlib.md5(rn[1].encode()).digest()))  # rate then deterministic hash
         archive.update(name for _, name in survivors[: len(survivors) - capacity])
     return sorted(archive)


### PR DESCRIPTION
When the mature pool exceeds capacity, `evaluate()` archives the lowest-rate survivors. Ties in rate were broken by alphabetical name order -- so a skill named `a-logging` with the same call rate as `z-logging` would always be archived first. Over many eviction cycles, this gives a systematic advantage to skills with names later in the alphabet.

This PR replaces the alphabetical tiebreaker with a deterministic hash of the skill name (`hashlib.md5`). The sort remains fully deterministic and reproducible, but tie-breaking is now independent of name ordering. Two skills with the same rate still get a consistent eviction order -- just not one that favors any particular naming convention.
