### PR TITLE
chore: add filterwarnings to pytest.ini to surface real issues

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -3,3 +3,8 @@ testpaths = tests
 pythonpath = src
 markers =
     live: requires a live Claude Code host; excluded from CI (run locally / under experiments/)
+filterwarnings =
+    error
+    ignore::DeprecationWarning
+    ignore::PendingDeprecationWarning
+    ignore::pytest.PytestUnknownMarkWarning


### PR DESCRIPTION
## Problem

`pytest.ini` has no `filterwarnings` section. Python 3.11+ emits deprecation warnings for various stdlib changes that accumulate in test output without being explicitly acknowledged or suppressed. This makes it harder to spot genuine warnings that indicate real compatibility issues.

## Fix

Add a `filterwarnings` section to `pytest.ini`:

- `error` — promote unhandled warnings to errors so they cannot accumulate silently
- `ignore::DeprecationWarning` — suppress stdlib deprecation noise (third-party libs, future Python compat)
- `ignore::PendingDeprecationWarning` — suppress pending-deprecation noise
- `ignore::pytest.PytestUnknownMarkWarning` — suppress unknown-mark warnings from custom markers

## Changes

- `pytest.ini`: add `filterwarnings` section

## Testing

```
python3 -m pytest tests/ -x -q --ignore=tests/test_e2e_live.py
409 passed
```
