### PR TITLE
fix: narrow snapshot exception handling in run_curator

### DIFF
--- a/src/autoharness/hook/spawn.py
+++ b/src/autoharness/hook/spawn.py
@@ -10,6 +10,7 @@ here: the reflector only appends intents, the promoter exclusively validates and
 
 ponytail: run() is the body of the "detached background job" (synchronous spawn→wait→drain); the "do not block the host Stop" detach is started in the background at the hook top level by the Phase 7 dispatch calling run(). spawn_fn is injectable (system tests use a fake reflector script in place of the real claude). Precise handling of the transcript upper-bound race (cap.md open) is still tolerated at v0.
 """
+import logging
 import os
 import subprocess
 import sys
@@ -17,6 +18,8 @@ import tarfile
 from pathlib import Path
 
 from autoharness import config
+
+log = logging.getLogger(__name__)
 from autoharness.hook import capture, promoter
 from autoharness.lib import counters, layer, sidecar, skill_store, validate
 
@@ -151,8 +154,10 @@ def run_curator(run_id, *, roots, repo_name=None, agent=None, claude_bin=None,
     roots = roots or {}
     try:
         _snapshot_skills(run_id, roots)
+    except OSError:
+        pass  # a transient disk issue must not silently disable curation
     except Exception:
-        pass  # a transient disk issue must not silently disable curation (Hermes's exact trade-off)
+        log.exception('unexpected snapshot error; curator running without safety net')
     spec = (spec_path or config.FORMAT_SPEC).read_text()
     bundle = build_curator_bundle(description_index(roots, agent_only=True), spec)
 


### PR DESCRIPTION
`run_curator()` wraps `_snapshot_skills()` in `except Exception: pass`. The comment says 'a transient disk issue must not silently disable curation,' but the broad catch also hides programming errors (TypeError, NameError, AttributeError) that indicate a bug in the snapshot code itself.

If the snapshot silently fails due to a real bug (not a transient disk issue), the curator runs unguarded -- a bad curator run has no rollback path.

**Fix:** narrow the silent pass to `OSError` (the actual 'transient disk issue' case). Other exceptions are now logged via `logging.exception()` so they surface in logs while still allowing curation to proceed.
