### PR TITLE
fix: emit diagnostic to stderr for handled but non-output verdicts

### DIFF
--- a/src/autoharness/hook/dispatch.py
+++ b/src/autoharness/hook/dispatch.py
@@ -144,6 +144,10 @@ def _emit(verdict):
             "hookEventName": "SessionStart",
             "additionalContext": result["context"],
         }}))
+        return
+    handled = verdict.get("handled")
+    if handled:
+        print(json.dumps({"handled": handled, "result": result}), file=sys.stderr)
 
 
 def main():


### PR DESCRIPTION
`_emit()` only produces stdout output for two cases: PreToolUse deny and SessionStart additionalContext. All other hook results -- Stop trigger verdicts, SessionEnd flush verdicts, PreToolUse skill/read counting results -- are computed by `dispatch()` but never written anywhere. The host hook process exits with code 0 and no output, making the entire pipeline invisible to the operator.

This adds a fallback: when a verdict was handled but didn't produce a `hookSpecificOutput`, write a structured JSON diagnostic to stderr. This keeps stdout clean (the host only reads `hookSpecificOutput` from there) while making the pipeline observable through standard error logging.
