### PR TITLE
fix(hook): enforce capture byte caps on UTF-8 byte length, not char count

### DIFF
--- a/src/autoharness/hook/capture.py
+++ b/src/autoharness/hook/capture.py
@@ -19,7 +19,12 @@ TRUNCATION_MARK = "...[truncated]"
 
 
 def _clip(line, cap):
-    return line if len(line) <= cap else line[:cap] + TRUNCATION_MARK
+    """Clip *line* so its UTF-8 encoding stays within *cap* bytes."""
+    encoded = line.encode("utf-8")
+    if len(encoded) <= cap:
+        return line
+    truncated = encoded[:cap].decode("utf-8", errors="ignore")
+    return truncated + TRUNCATION_MARK
 
 
 def window(transcript_path, offset=0, *, max_record_bytes=None, max_window_bytes=None,
@@ -37,7 +42,7 @@ def window(transcript_path, offset=0, *, max_record_bytes=None, max_window_bytes
              for line in data[offset:].decode("utf-8", errors="replace").splitlines()]
     kept, total = [], 0
     for line in reversed(lines):
-        total += len(line) + 1
+        total += len(line.encode("utf-8")) + 1
         if total > window_cap:
             kept.append(TRUNCATION_MARK)
             break


### PR DESCRIPTION
## Problem

`capture.py` names its caps in bytes (`CAPTURE_MAX_RECORD_BYTES = 4_000`, `CAPTURE_MAX_WINDOW_BYTES = 200_000`), but `_clip()` on line 22 uses `len(line)` which counts **Unicode characters**, not bytes. A line of 3,500 CJK characters passes the 4,000 cap while occupying ~10,500 UTF-8 bytes. The same mismatch applies to the window accumulation on line 40 (`total += len(line) + 1`).

The practical effect is that multi-byte-heavy transcript records silently exceed the intended byte budget, inflating the reflector child session stdin past the documented limit.

## Solution

- `_clip()` now encodes to UTF-8 before comparing against `cap`, and truncates the **byte slice** (then decodes back, dropping any incomplete trailing codepoint).
- `window()` accumulates `len(line.encode("utf-8")) + 1` instead of `len(line) + 1` so the window cap is enforced in actual bytes.

Two small changes, both in `src/autoharness/hook/capture.py`. No API surface changes.

## Testing

- `python3 -m py_compile` on the changed file passes.
- ASCII-only transcripts behave identically (byte length == char length).
- A synthetic line of 5,000 three-byte characters (15,000 bytes) now gets clipped to the 4,000-byte cap rather than passing through.
