### PR TITLE
fix(hook): skip sidecar overwrite on duplicate create-intent replay

### DIFF
--- a/src/autoharness/hook/promoter.py
+++ b/src/autoharness/hook/promoter.py
@@ -130,7 +130,10 @@ def _land(action, intent, body, level, name, root):
     evidence_ref = _materialize_evidence(level, name, intent.get("evidence"), root)
     skill_store.write_body(level, name, body, root)
     if action == "create":
-        sidecar.create(level, name, counters.request_count(level, root), root)
+        existing = sidecar.read(level, name, root)
+        if not existing:
+            sidecar.create(level, name, counters.request_count(level, root), root)
+        # crash-replay: sidecar already exists — skip create to preserve counters
     else:
         sidecar.bump_patch(level, name, root)  # update/patch: feeds the reuse-after-improvement pair
     ledger.append(level, name, _led(intent, evidence_ref), root)


### PR DESCRIPTION
## Problem

`promoter._land()` unconditionally calls `sidecar.create()` for every `create` action (line 133 of `src/autoharness/hook/promoter.py`). `sidecar.create()` overwrites the entire sidecar, resetting `use`, `view`, `patch`, and `anchor` to zero.

If a crash occurs between landing the skill and clearing the intent queue, the next `drain()` re-processes the create intent. The `self_produced` gate only applies to `_MODIFY` actions (update/patch/remove_file/delete), so `create` skips the existence check entirely. A crash-replay of a create intent erases all accumulated usage history, which at the next graduation review triggers archival for "genuine dormancy" — the skill gets evicted because its counter was wiped, not because it was actually unused.

## Solution

Read the sidecar before calling `sidecar.create()`. If it already exists (non-empty dict), skip the create — this is a crash-replay and the counters should be preserved. If the sidecar is missing (empty dict from `sidecar.read()`), proceed with create as before.

This makes `_land()` idempotent for create intents, matching the at-least-once guarantee described in the module docstring.

## Testing

- `python3 -m py_compile` on the changed file passes.
- Fresh create (no existing sidecar): behavior unchanged, `sidecar.create()` fires normally.
- Replay create (sidecar already exists): `sidecar.create()` is skipped, preserving accumulated `use`/`view`/`patch`/`anchor` counters.
