### PR TITLE
fix(lib): serialize counter bumps with fcntl flock to prevent lost increments

### DIFF
--- a/src/autoharness/lib/counters.py
+++ b/src/autoharness/lib/counters.py
@@ -8,6 +8,7 @@ state area (cap.md: session-scoped, written to this repo's .claude, not into liv
 ponytail: read-modify-write is not atomic across processes; the lock for the global request counter
 under concurrent multi-repo writes is deferred to mng.
 """
+import fcntl
 import re
 
 from autoharness.lib import atomic, layer
@@ -23,8 +24,17 @@ def _read_int(p):
 
 
 def _bump(p, delta=1):
-    value = _read_int(p) + delta
-    atomic.write_text(p, str(value))
+    """Read-modify-write under an exclusive lock so concurrent hook processes
+    cannot both read the same value and lose an increment."""
+    lock_path = p.with_suffix(p.suffix + ".lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(lock_path, "w") as lock_fd:
+        fcntl.flock(lock_fd, fcntl.LOCK_EX)
+        try:
+            value = _read_int(p) + delta
+            atomic.write_text(p, str(value))
+        finally:
+            fcntl.flock(lock_fd, fcntl.LOCK_UN)
     return value
 
 


### PR DESCRIPTION
## Problem

`counters._bump()` in `src/autoharness/lib/counters.py` (line 25) does a separate read, increment, and atomic write — the read-modify-write is not atomic across processes. Two concurrent Stop hooks (e.g., from overlapping sessions sharing the same `~/.claude` root) can both read the same counter value, increment it, and write back, losing one increment.

The module docstring already acknowledges this and defers the fix, but the global request counter is bumped on every Stop from every repo. Lost increments shrink the MNG lifecycle-rate denominator, making skills appear more frequently used than they actually are and skewing capacity contention eviction decisions.

## Solution

Wrap the read-modify-write in `_bump()` with `fcntl.flock(LOCK_EX)` on a per-counter `.lock` file. The lock is acquired before reading, held through the atomic write, and released in a `finally` block. This serializes concurrent bumps from separate processes without changing the API or any caller.

The lock file sits next to the counter file (`<name>.lock`) and is created lazily — no migration needed.

## Testing

- `python3 -m py_compile` on the changed file passes.
- Single-process bump: behavior unchanged (lock is uncontended, overhead negligible).
- Two concurrent bump processes: both increments are now preserved instead of one being lost.
